### PR TITLE
Added methods to get "otherContent" annotation lists

### DIFF
--- a/src/AnnotationList.ts
+++ b/src/AnnotationList.ts
@@ -1,0 +1,49 @@
+namespace Manifesto {
+    export class AnnotationList extends JSONLDResource implements IAnnotationList {
+        options: IManifestoOptions;
+        label: string;
+        isLoaded: boolean;
+
+        constructor(label, jsonld?: any, options?: IManifestoOptions) {
+            super(jsonld);
+            this.label = label;
+            this.options = <IManifestoOptions>options;
+        }
+
+        getIIIFResourceType(): IIIFResourceType {
+            return new IIIFResourceType(Utils.normaliseType(this.getProperty('type')));
+        }
+
+        getLabel(): string {
+            return this.label
+        }
+
+        getResources(): Annotation[] {
+            const resources = this.getProperty('resources');
+
+            return resources.map(resource => new Annotation(resource, this.options));
+        }
+
+        load(): Promise<AnnotationList> {
+            return new Promise<AnnotationList>((resolve, reject) => {
+                if (this.isLoaded) {
+                    resolve(this);
+                } else {
+                    let id: string = this.__jsonld.id;
+
+                    if (!id) {
+                        id = this.__jsonld['@id']
+                    }
+
+                    Utils.loadResource(id).then(data => {
+                        this.__jsonld = JSON.parse(data);
+                        this.context = this.getProperty('context');
+                        this.id = this.getProperty('id');
+                        this.isLoaded = true;
+                        resolve(this);
+                    }).catch(reject);
+                }
+            });
+        }
+    }
+}

--- a/src/IAnnotationList.ts
+++ b/src/IAnnotationList.ts
@@ -1,0 +1,5 @@
+namespace Manifesto {
+    export interface IAnnotationList extends IJSONLDResource {
+
+    }
+}

--- a/test/annotation-list.js
+++ b/test/annotation-list.js
@@ -1,0 +1,32 @@
+var manifesto = require('../dist/server/manifesto');
+var should = require('chai').should();
+var manifests = require('./fixtures/manifests');
+require('./shared');
+
+describe('#loadsAnnotationList', function() {
+  var manifest, canvas, annotationList;
+  it('loads successfully and maps objects', function (done) {
+    manifesto.loadManifest(manifests.wunder).then(function(data) {
+      manifest = manifesto.create(data);
+      canvas = manifest.getSequenceByIndex(0).getCanvasById('http://wellcomelibrary.org/iiif/b18035723/canvas/c2');
+      annotationList = canvas.getOtherContent();
+      annotationList.then(function(annotationList) {
+        should.equal(annotationList.length, 1);
+        should.equal(annotationList[0].getLabel(), 'Text of this page');
+        should.equal(annotationList[0].id, 'https://wellcomelibrary.org/iiif/b18035723/contentAsText/2');
+        annotationList[0].getResources();
+
+        var arrayOfList = Array.prototype.slice.call(annotationList[0].getResources());
+        should.equal(arrayOfList.length, 35);
+
+        var annotation = arrayOfList[0];
+        should.equal(annotation.getBody().length, 0);
+        should.equal(annotation.getMotivation().toString(), 'sc:painting');
+        should.equal(annotation.getOn(), 'https://wellcomelibrary.org/iiif/b18035723/canvas/c2#xywh=928,317,609,56');
+        should.equal(annotation.getResource().getType().toString(), 'contentastext');
+        done();
+      });
+    });
+  });
+
+});

--- a/test/fixtures/wunder.json
+++ b/test/fixtures/wunder.json
@@ -184,7 +184,7 @@
           ],
           "otherContent": [
             {
-              "@id": "http://wellcomelibrary.org/iiif/b18035723/contentAsText/2",
+              "@id": "https://wellcomelibrary.org/iiif/b18035723/contentAsText/2",
               "@type": "sc:AnnotationList",
               "label": "Text of this page"
             }


### PR DESCRIPTION
Spec: http://iiif.io/api/presentation/2.0/#other-content-resources

**Implementation notes**
* Conforms only to current annotation spec (OpenAnnotations, not W3C yet)
* Does not expand "on" properties if presented as fragments (`#xywh=`)
