### PR TITLE
Adds npm script aliases and creates a documented package release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ http://blog.edsilv.com/manifesto/
     npm install
     npm build
     npm test
+
+### Publishing Package
+
+1. Bump the version locally using `npm version` on a branch other than `master`. Example: `npm version patch -m 'bump to v3.0.42'`
+1. Push the bump version branch to GitHub and create a pull request to `master`.
+1. After the pull request is merged, checkout `master` and pull the latest changes. `git checkout master && git pull`
+1. Run `npm publish`
+1. Push the git tags created `git push --tags`

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ http://blog.edsilv.com/manifesto/
 
     git clone https://github.com/iiif-commons/manifesto.git
     npm install
-    gulp
-    gulp test
+    npm build
+    npm test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gulp",
     "build-docs": "rimraf docs && typedoc --options typedoc.json src/ && touch docs/.nojekyll",
+    "prepare": "npm run build",
     "test": "gulp test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "./dist/server/manifesto.js",
   "types": "./dist/manifesto.d.ts",
   "scripts": {
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/ && touch docs/.nojekyll"
+    "build": "gulp",
+    "build-docs": "rimraf docs && typedoc --options typedoc.json src/ && touch docs/.nojekyll",
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR aims to document the release process for manifesto, without relying on built `dist` being committed to PR's.