### PR TITLE
npmignore coverage directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ bower.json
 gulpfile.config.js
 gulpfile.js
 bower_components
+coverage
 docs
 src
 tasks


### PR DESCRIPTION
Currently this is getting distributed. See: https://unpkg.com/manifesto.js@3.0.9/