### PR TITLE
Fix logic for getting values from LabelValuePair

### DIFF
--- a/src/LabelValuePair.ts
+++ b/src/LabelValuePair.ts
@@ -39,14 +39,7 @@ export class LabelValuePair {
 
   public getValue(): string | null {
     if (this.value) {
-      var locale: string = this.defaultLocale;
-
-      // if the label has a locale, prefer that to the default locale
-      if (this.label && this.label.length && this.label[0].locale) {
-        locale = this.label[0].locale;
-      }
-
-      return LanguageMap.getValue(this.value, locale);
+      return LanguageMap.getValue(this.value, this.defaultLocale);
     }
 
     return null;
@@ -54,14 +47,7 @@ export class LabelValuePair {
 
   public getValues(): Array<string | null> {
     if (this.value) {
-      var locale: string = this.defaultLocale;
-
-      // if the label has a locale, prefer that to the default locale
-      if (this.label && this.label.length && this.label[0].locale) {
-        locale = this.label[0].locale;
-      }
-
-      return LanguageMap.getValues(this.value, locale);
+      return LanguageMap.getValues(this.value, this.defaultLocale);
     }
 
     return [];

--- a/test/fixtures/cardiganshire.json
+++ b/test/fixtures/cardiganshire.json
@@ -7,12 +7,12 @@
     {
       "label":[
         {
-          "@value":"Title",
-          "@language": "en"
-        },
-        {
           "@value":"Teitl",
           "@language": "cy-GB"
+        },
+        {
+          "@value":"Title",
+          "@language": "en"
         }
       ],
       "value":"Cardiganshire Constabulary register of criminals"

--- a/test/tests/LabelValuePair.test.js
+++ b/test/tests/LabelValuePair.test.js
@@ -1,22 +1,29 @@
 var expect = require('chai').expect;
-var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
-var manifests = require('../fixtures/manifests');
-var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var manifestSources = require('../fixtures/manifests');
 
-var manifest;
+var manifests = {};
 
 describe('LabelValuePair', function() {
-    beforeEach(function(done) {
-        manifesto.loadManifest(manifests['4']).then(function(data) {
-            manifest = manifesto.parseManifest(data);
-            done();
-        });
+    before(function(done) {
+        // Load manifest fixtures
+        Promise.all(
+            ['4', 'cardiganshire']
+                .map(manifestId => manifesto.loadManifest(manifestSources[manifestId]).then(
+                    data => new Promise((resolve) => {
+                        manifests[manifestId] = manifesto.parseManifest(data);
+                        resolve();
+                    }))))
+            .then(() => done());
     })
     describe('#getValues', function() {
         it('returns an array of language values', function() {
-            var metadata = manifest.getMetadata().map(m => m.getValues());
+            var metadata = manifests['4'].getMetadata().map(m => m.getValues());
             expect(metadata[0]).to.eql(['some date', 'some other date']);
+        });
+        it('returns the sole value when the labels carry a locale and the first locale does not match the default locale', function() {
+            var metadata = manifests['cardiganshire'].getMetadata().map(m => m.getValues());
+            expect(metadata[0]).to.eql(['Cardiganshire Constabulary register of criminals']);
         });
     });
 });


### PR DESCRIPTION
This fixes a faulty heuristic introduced in #60, which would override the default locale with the locale of the first label and then attempt to fetch the value with that logic.

This heuristic breaks e.g. in the simple case were labels are available in multiple languages, but the values only available in one. If the first language of the labels did not correspond to the language of the value, the client would get no value back.

This is clearly in violation of the algorithm prescribed for IIIF property values in the [Presentation API spec](https://iiif.io/api/presentation/2.1/#language-of-property-values), which states:

> If none of the values have a language associated with them, the client must display all of the values.

and

> If all of the values have a language associated with them, and none match the language preference, the client must select a language and display all of the values associated with that language.

as well as

> If some of the values have a language associated with them, but none match the language preference, the client must display all of the values that do not have a language associated with them.