### PR TITLE
added method to get homepage

### DIFF
--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -56,6 +56,16 @@ export class IIIFResource extends ManifestResource {
     return new PropertyValue([], this.options.locale);
   }
 
+  getHomepage(): string | null {
+    let homepage: any = this.getProperty("homepage");
+    if (!homepage) return null;
+    if (typeof homepage == "string") return homepage;
+    if (Array.isArray(homepage) && homepage.length) {
+      homepage = homepage[0];
+    }
+    return homepage["@id"] || homepage.id;
+  }
+
   getIIIFResourceType(): IIIFResourceType {
     return <IIIFResourceType>Utils.normaliseType(this.getProperty("type"));
   }


### PR DESCRIPTION
Hello,

I'm having some trouble modifying the "share URL" link in the Universal Viewer. Because we're using version 3 of the Presentation API, we no longer have the related property- but in a conversation in the #dev channel on the UniversalViewer Slack, Andy Irving recommended using homepage as a replacement. 

This PR is to allow manifesto.js to get the homepage from a manifest- if this PR is ok, I'll follow up with a PR to the UniversalViewer code next.

Please let me know if there are any changes I can make to this or any additional code I can submit. Thanks so much for considering this.

John