### PR TITLE
Range duration bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./dist-esmodule/index.js",
   "browser": "./dist-esmodule/index.js",
   "unpkg": "./dist-umd/manifesto.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist-esmodule/index.d.ts",
   "scripts": {
     "build:commonjs": "tsc",
     "build:docs": "rimraf -rf docs && typedoc --out docs --name manifesto --theme default --ignoreCompilerErrors --experimentalDecorators --emitDecoratorMetadata --target ES6 --moduleResolution node --preserveConstEnums --stripInternal --suppressExcessPropertyErrors --suppressImplicitAnyIndexErrors --module commonjs src/ && touch docs/.nojekyll",

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -34,6 +34,9 @@ export class IIIFResource extends ManifestResource {
     this.options = Object.assign(defaultOptions, options);
   }
 
+  /**
+   * @deprecated
+   */
   getAttribution(): PropertyValue {
     //console.warn('getAttribution will be deprecated, use getRequiredStatement instead.');
 

--- a/src/PropertyValue.ts
+++ b/src/PropertyValue.ts
@@ -2,7 +2,7 @@ import Language from "./Language";
 import { Utils } from "./Utils";
 
 /** Utility class to hold one or more values with their associated (optional) locale */
-class LocalizedValue implements Language {
+export class LocalizedValue implements Language {
   _value: string | string[];
   _locale?: string;
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -102,7 +102,7 @@ export class Utils {
   }
 
   static normaliseType(type: string): string {
-    type = type.toLowerCase();
+    type = (type || "").toLowerCase();
 
     if (type.indexOf(":") !== -1) {
       const split: string[] = type.split(":");


### PR DESCRIPTION
This is a change that we might want to split into its own method. I will break down how the duration used to work and how this duration works.

### Original implementation

* It assumes that the ranges are sequential - in the source canvas, with the first targeting the start of the canvas, and the end targeting the end.
* It assumes the ranges are all from the same canvas, with the start and end being numbers representing the progress through that canvas.

Here is the annotated source of the original implementation.

<details>
  <summary>Click to see the annotated source</summary>

```typescript
let start: number | undefined;
let end: number | undefined;

// There are 2 paths for this implementation. Either we have a list of canvases, or a list of ranges (which may have a list of ranges).
// This is one of the limitations of this implementation.
if (this.canvases && this.canvases.length) {

  // When we loop through each of the canvases we are expecting to see a fragment or a link to the whole canvas.
  // For example - if we have http://example.org/canvas#t=1,100 it will extract 1 and 100 as the start and end.
  for (let i = 0; i < this.canvases.length; i++) {
    const canvas: string = this.canvases[i];
    let temporal: number[] | null = Utils.getTemporalComponent(canvas);
    if (temporal && temporal.length > 1) {
      if (i === 0) {
        start = Number(temporal[0]);
      }

      if (i === this.canvases.length - 1) {
        end = Number(temporal[1]);
      }
    }
  }
} else {

  // In this second case, where there are nested ranges, we recursively get the duration
  // from each of the child ranges (a start and end) and then choose the first and last for the bounds of this range.
  const childRanges: Manifesto.IRange[] = this.getRanges();

  for (let i = 0; i < childRanges.length; i++) {
    const childRange: Manifesto.IRange = childRanges[i];

    const duration: Duration | undefined = childRange.getDuration();

    if (duration) {
      if (i === 0) { // <-- PROBLEM 1: Cannot guarantee ranges are sequential 
        start = duration.start;
      }

      if (i === childRanges.length - 1) {
        end = duration.end; // <-- PROBLEM 2: The end of this duration may be targeting a different canvas.
      }
    }
  }
}

if (start !== undefined && end !== undefined) {
  return new Duration(start, end);
}

return undefined;
```

</details>

## New implementation

* Fixes the assumption for sequential ranges
* Produces the same results as above for manifests with sequential ranges
* Do **NOT** fix any problems with targeting different canvases or ranges with gaps.

<details>
    <summary>Click to see the annotated source code</summary>

```typescript
// For this implementation, we want to catch SOME of the temporal cases - i.e. when there is a t=1,100
if (this.canvases && this.canvases.length) {

  const startTimes: number[] = [];
  const endTimes: number[] = [];

  // When we loop through all of the canvases we store the recorded start and end times.
  // Then we choose the maximum and minimum values from this. This will give us a more accurate duration for the
  // Chosen range. However this is still not perfect and does not cover more complex ranges. These cases are out of 
  // scope for this change.
  for (const canvas of this.canvases) {
    if (!canvas) continue;
    const [, canvasId, start, end] = (canvas.match(
      /(.*)#t=([0-9.]+),?([0-9.]+)?/
    ) || [undefined, canvas]) as string[];
    
    if (canvasId) {
      startTimes.push(parseFloat(start));
      endTimes.push(parseFloat(end));
    }
  }

  if (startTimes.length && endTimes.length) {
    return new Duration(
      Math.min(...startTimes),
      Math.max(...endTimes)
    );
  }
} else {
  // get child ranges and calculate the start and end based on them
  const childRanges: Manifesto.IRange[] = this.getRanges();
  const startTimes: number[] = [];
  const endTimes: number[] = [];

  // Once again, we use a max/min to get the ranges.
  for (const childRange of childRanges) {
    const duration = childRange.getDuration();
    if (duration) {
      startTimes.push(duration.start);
      endTimes.push(duration.end);
    }
  }

  // And return the minimum as the start, and the maximum as the end.
  if (startTimes.length && endTimes.length) {
    return new Duration(
      Math.min(...startTimes),
      Math.max(...endTimes)
    );
  }
}
```

</details>


### Summary

The new implementation fixes one of the problems with getting a duration for a range - and expands to more cases, but does not change the signature of the `getDuration` for a range. It's difficult to quantify what the duration of a range should be. For example:

```
                   Canvas 1                         Canvas 2
Canvases |  [ --------------------------- ] [ ----------------------------- ]
Ranges   |        [ ---- ]          [ ---------- ]       [ ---- ]

Duration?|        [ ------------------------------------------- ]
Duration?|        [ ---- ][ ---------- ][ ---- ]
```

I don't think a start and end is enough information to give a good representation of what the duration of a range is in all cases. Even with the canvases, it might be useless to say that the start of the duration is canvas 1 at 10 seconds and the end is canvas 3 at 50 seconds but the time between them is 30 seconds, if it's all chopped up.

If the duration is purely to show the duration to the user, then I think a single number where the duration of all of the time slices are added together would be the simplest. However I know that this is also used to chop up with the start and end points - which makes it a bit more complicated. 

This addition was required for some of the BL use cases. 

I will be rebasing on the new modules.

### Additional changes
* Added link to types in package json
* Removed warning on getAttribution - Manifesto is a compatibility layer, should annotate this to developers with an `@deprecated` but not to end users.
* Made type utility accept undefined input