### PR TITLE
Added support for Presentation 3 services property

### DIFF
--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -276,6 +276,7 @@ export class Sequence extends ManifestResource {
   getViewingDirection(): ViewingDirection | null {
     if (this.getProperty("viewingDirection")) {
       return this.getProperty("viewingDirection");
+      // @ts-ignore
     } else if ((<Manifest>this.options.resource).getViewingDirection) {
       return (<Manifest>this.options.resource).getViewingDirection();
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1040,9 +1040,20 @@ export class Utils {
     parentResource: JSONLDResource,
     id: string
   ): JSONLDResource {
-    return <JSONLDResource>(
-      Utils.traverseAndFind(parentResource.__jsonld, "@id", id)
+    const presentation2Resource = Utils.traverseAndFind(
+      parentResource.__jsonld,
+      "@id",
+      id
     );
+    if (presentation2Resource) {
+      return presentation2Resource as JSONLDResource;
+    }
+
+    return Utils.traverseAndFind(
+      parentResource.__jsonld,
+      "id",
+      id
+    ) as JSONLDResource;
   }
 
   /**
@@ -1084,26 +1095,41 @@ export class Utils {
     }
 
     const services: Service[] = [];
-    if (!service) return services;
 
     // coerce to array
     if (!Array.isArray(service)) {
       service = [service];
     }
 
+    if (resource.__jsonld && resource.__jsonld.services) {
+      service.push(...resource.__jsonld.services);
+    }
+
+    if (service.length === 0) {
+      return services;
+    }
+
     for (let i = 0; i < service.length; i++) {
       const s: any = service[i];
 
-      if (typeof s === "string") {
+      if (!s) {
+        continue;
+      }
+
+      const id = typeof s === "string" ? s : s.id || s["@id"];
+
+      if (id) {
         const r: JSONLDResource = this.getResourceById(
           resource.options.resource,
-          s
+          id
         );
 
         if (r) {
           services.push(new Service(r.__jsonld || r, resource.options));
+          continue;
         }
-      } else {
+      }
+      if (typeof s !== "string") {
         services.push(new Service(s, resource.options));
       }
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1028,8 +1028,6 @@ export class Utils {
     for (let i = 0; i < services.length; i++) {
       const service: Service = services[i];
 
-      console.log(service.getProfile(), '==', profile);
-
       if (service.getProfile() === profile) {
         return service;
       }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1028,6 +1028,8 @@ export class Utils {
     for (let i = 0; i < services.length; i++) {
       const service: Service = services[i];
 
+      console.log(service.getProfile(), '==', profile);
+
       if (service.getProfile() === profile) {
         return service;
       }
@@ -1084,6 +1086,7 @@ export class Utils {
   }
 
   static getServices(resource: any): Service[] {
+
     let service: any;
 
     // if passing a manifesto-parsed object, use the __jsonld.service property,

--- a/test/fixtures/bl-new-auth.json
+++ b/test/fixtures/bl-new-auth.json
@@ -1,0 +1,366 @@
+{
+  "@context": [
+    "http://iiif.io/api/auth/1/context.json",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000002/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "George Evans / Basil Bunting"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Full title"
+        ]
+      },
+      "value": {
+        "en": [
+          "George Evans / Basil Bunting"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Collection"
+        ]
+      },
+      "value": {
+        "en": [
+          "Robert Hampson tapes"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "1 compact cassette"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Usage"
+        ]
+      },
+      "value": {
+        "en": [
+          "<span>Rights unassigned  staff access only</span>"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Held by"
+        ]
+      },
+      "value": {
+        "en": [
+          "The British Library"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Digitised by"
+        ]
+      },
+      "value": {
+        "en": [
+          "The British Library 2018"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Digitisation funded by"
+        ]
+      },
+      "value": {
+        "en": [
+          "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Identifier"
+        ]
+      },
+      "value": {
+        "en": [
+          "C1700/01"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Shelfmark"
+        ]
+      },
+      "value": {
+        "en": [
+          "C1700/01"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Link to catalogue"
+        ]
+      },
+      "value": {
+        "en": [
+          "<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8107626'>View the catalogue record</a>"
+        ]
+      }
+    }
+  ],
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Copyright and Usage"
+      ]
+    },
+    "value": {
+      "en": [
+        "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8107626\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https://www.bl.uk/about-us",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "The British Library"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https://www.bl.uk/",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "en": [
+              "The British Library"
+            ]
+          }
+        }
+      ],
+      "logo": [
+        {
+          "id": "https://www.bl.uk/images/bl_logo_100.gif",
+          "type": "Image",
+          "format": "image/gif"
+        }
+      ]
+    }
+  ],
+  "services": [
+    {
+      "id": "https://api.bl.uk/auth/iiif/login",
+      "type": "AuthCookieService1",
+      "profile": "http://iiif.io/api/auth/1/login",
+      "description": {
+        "en": [
+          "Some portions of this recording may be unavailable due to rights restrictions."
+        ]
+      },
+      "header": {
+        "en": [
+          "Please Log-In"
+        ]
+      },
+      "label": {
+        "en": [
+          "Login to The British Library"
+        ]
+      },
+      "service": [
+        {
+          "id": "https://api.bl.uk/auth/iiif/token",
+          "type": "AuthTokenService1",
+          "profile": "http://iiif.io/api/auth/1/token"
+        }
+      ]
+    },
+    {
+      "id": "http://access.bl.uk/item/share/ark:/81055/vdc_100063181190.0x000002",
+      "type": "Service",
+      "profile": "http://universalviewer.io/share-extensions-profile"
+    }
+  ],
+  "homepage": [
+    {
+      "id": "http://access.bl.uk/item/viewer/ark:/81055/vdc_100063181190.0x000002",
+      "type": "Text",
+      "format": "text/html",
+      "label": {
+        "en": [
+          "View at the British Library"
+        ]
+      }
+    }
+  ],
+  "behavior": [
+    "auto-advance"
+  ],
+  "items": [
+    {
+      "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000004",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "Tape 1 Side 1"
+        ]
+      },
+      "duration": 2808.8800000000001,
+      "items": [
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000004/anno1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000004/anno1/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000004#t=00.00,2808.88",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100063181190.0x00000d/manifest.mpd",
+                    "format": "application/dash+xml",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/auth/iiif/login",
+                        "type": "AuthCookieService1"
+                      },
+                      {
+                        "id": "https://api.bl.uk/media/dash/ark:/81055/vdc_100063181190.0x00000d/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100063181190.0x00000d/index.m3u8",
+                    "format": "application/vnd.apple.mpegURL",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/auth/iiif/login",
+                        "type": "AuthCookieService1"
+                      },
+                      {
+                        "id": "https://api.bl.uk/media/hls/ark:/81055/vdc_100063181190.0x00000d/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "seeAlso": [
+                {
+                  "id": "https://iiif-waveforms.s3.amazonaws.com/vdc_100063181190.0x00000c.dat",
+                  "type": "Dataset",
+                  "format": "application/octet-stream",
+                  "profile": "http://waveform.prototyping.bbc.co.uk"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000005",
+      "type": "Canvas",
+      "label": {
+        "en": [
+          "Tape 1 Side 2"
+        ]
+      },
+      "duration": 1090.28,
+      "items": [
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000005/anno2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000005/anno2/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100063181190.0x000005#t=00.00,1090.28",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100063181190.0x00000f/manifest.mpd",
+                    "format": "application/dash+xml",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/auth/iiif/login",
+                        "type": "AuthCookieService1"
+                      },
+                      {
+                        "id": "https://api.bl.uk/media/dash/ark:/81055/vdc_100063181190.0x00000f/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100063181190.0x00000f/index.m3u8",
+                    "format": "application/vnd.apple.mpegURL",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/auth/iiif/login",
+                        "type": "AuthCookieService1"
+                      },
+                      {
+                        "id": "https://api.bl.uk/media/hls/ark:/81055/vdc_100063181190.0x00000f/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "seeAlso": [
+                {
+                  "id": "https://iiif-waveforms.s3.amazonaws.com/vdc_100063181190.0x00000e.dat",
+                  "type": "Dataset",
+                  "format": "application/octet-stream",
+                  "profile": "http://waveform.prototyping.bbc.co.uk"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/manifests.js
+++ b/test/fixtures/manifests.js
@@ -56,7 +56,8 @@ module.exports = {
     "witnesstopeter": "http://localhost:3001/witnesstopeter.json",
     "wunder": "http://localhost:3001/wunder.json",
     "deephierarchytop": "http://localhost:3001/deephierarchytop.json",
-    "sctagracilis": "http://localhost:3001/sctagracilis.json"
+    "sctagracilis": "http://localhost:3001/sctagracilis.json",
+    "bl-new-auth": "http://localhost:3001/bl-new-auth.json"
     //"query-bodleian": "http://iiif.bodleian.ox.ac.uk/iiif/manifest/f22e9dae-c070-48eb-be0b-aa6c5bc195a6.json",
     //"query-gams": "http://gams.uni-graz.at/cocoon/mets2json?source=http%3A%2F%2Fgams.uni-graz.at%2Farchive%2Fget%2Fo%3Asrbas.1535%2FMETS_SOURCE"
 };

--- a/test/tests/correspondance.js
+++ b/test/tests/correspondance.js
@@ -8,7 +8,7 @@ var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest, sequence, canvas, imageService;
 
-describe.only('#loadsCorrespondance', function() {
+describe('#loadsCorrespondance', function() {
     it('loads successfully', function (done) {
         manifesto.loadManifest(manifests.correspondance).then(function(data) {
             manifest = manifesto.parseManifest(data);

--- a/test/tests/correspondance.js
+++ b/test/tests/correspondance.js
@@ -8,7 +8,7 @@ var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest, sequence, canvas, imageService;
 
-describe('#loadsCorrespondance', function() {
+describe.only('#loadsCorrespondance', function() {
     it('loads successfully', function (done) {
         manifesto.loadManifest(manifests.correspondance).then(function(data) {
             manifest = manifesto.parseManifest(data);
@@ -24,7 +24,7 @@ describe('#loadsCorrespondance', function() {
         expect(annotation).to.exist;
         var resource = annotation.getResource();
         expect(resource).to.exist;
-        var profile = ServiceProfile.IMAGE_2_LEVEL_1;
+        var profile = ServiceProfile.IMAGE_2_LEVEL_0; // Was previously LEVEL_1 but this does not exist.
         imageService = resource.getService(profile);
         expect(imageService).to.exist;
     });

--- a/test/tests/new-bl-auth.js
+++ b/test/tests/new-bl-auth.js
@@ -1,0 +1,23 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../dist-commonjs/');
+var manifests = require('../fixtures/manifests');
+
+var manifest;
+
+describe('#newblauth', function() {
+
+    it('loads successfully', function (done) {
+        manifesto.loadManifest(manifests['bl-new-auth']).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    it('has joined range value', function () {
+        var canvas = manifest.getCanvasByIndex(0);
+
+        expect(canvas.getServices()).to.have.lengthOf(2);
+    });
+
+});


### PR DESCRIPTION
1. Adds check for resources with `id` in addition to `@id` to find services from parent resources
2. Adds `services` to pool of services to check when listing all services.
3. Always looks for references to services in parent resources - **this might be problematic**
4. Fixes previously passing test where a level1 image service was requested but only level0 was available. Test reflects ground truth but unsure if functionality relied on this bug.

For 3. an alternative to always checking would be to determine that the service doesn't have enough data:
```
{
  "id": "https://api.bl.uk/auth/iiif/login",
  "type": "AuthCookieService1"
}
```
Which references this in the `manifest.services` block:
```
{
  "id": "https://api.bl.uk/auth/iiif/login",
  "type": "AuthCookieService1",
  "profile": "http://iiif.io/api/auth/1/login",
  "description": {
    "en": [
      "Some portions of this recording may be unavailable due to rights restrictions."
    ]
  },
  "header": {
    "en": [
      "Please Log-In"
    ]
  },
  "label": {
    "en": [
      "Login to The British Library"
    ]
  },
  "service": [
    {
      "id": "https://api.bl.uk/auth/iiif/token",
      "type": "AuthTokenService1",
      "profile": "http://iiif.io/api/auth/1/token"
    }
  ]
}
```

The lack of profile might be enough? It's possible that in misconfigured manifests this would cause issues, if you had 2 services with the same identifier when you looked for the service recursively in the JSON-LD it would always resolve the first. Even if that service had a different structure.

I believe this is correct behaviour though, short of merging all services we find. cc @tomcrane 