### PR TITLE
Update getRights and getLogo for v3 manifests

### DIFF
--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -370,7 +370,9 @@ export class Canvas extends Resource {
     const on = resourceAnnotation.getProperty("on");
     // IIIF v3
     const target = resourceAnnotation.getProperty("target");
-    if (!on || !target) { return undefined; }
+    if (!on || !target) {
+      return undefined;
+    }
     const fragmentMatch = (on || target).match(/xywh=(.*)$/);
     if (!fragmentMatch) return undefined;
     return fragmentMatch[1].split(",").map(str => parseInt(str, 10));

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -87,7 +87,8 @@ export class IIIFResource extends ManifestResource {
         return null;
       }
 
-      logo = provider[0].logo;
+      // get the first object in the provider array with a logo
+      logo = provider.find(item => item.logo !== undefined);
     }
 
     if (!logo) return null;

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -87,7 +87,9 @@ export class IIIFResource extends ManifestResource {
         return null;
       }
 
-      logo = provider[0].logo;
+      // get the first agent in the provider array with a logo
+      const agent = provider.find(item => item.logo !== undefined);
+      logo = typeof agent.logo === "undefined" ? null : agent.logo;
     }
 
     if (!logo) return null;
@@ -106,7 +108,13 @@ export class IIIFResource extends ManifestResource {
   }
 
   getRights(): string | null {
-    return this.getProperty("rights");
+    var rights = this.getProperty("rights");
+    if (!rights) return null;
+    if (typeof rights === "string") return rights;
+    if (Array.isArray(rights) && rights.length) {
+      rights = rights[0];
+    }
+    return rights["@id"] || rights.id;
   }
 
   getNavDate(): Date {

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -89,7 +89,7 @@ export class IIIFResource extends ManifestResource {
 
       // get the first agent in the provider array with a logo
       const agent = provider.find(item => item.logo !== undefined);
-      logo = agent.logo
+      logo = typeof agent.logo === "undefined" ? null : agent.logo;
     }
 
     if (!logo) return null;

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -87,8 +87,9 @@ export class IIIFResource extends ManifestResource {
         return null;
       }
 
-      // get the first object in the provider array with a logo
-      logo = provider.find(item => item.logo !== undefined);
+      // get the first agent in the provider array with a logo
+      const agent = provider.find(item => item.logo !== undefined);
+      logo = agent.logo
     }
 
     if (!logo) return null;

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -105,6 +105,10 @@ export class IIIFResource extends ManifestResource {
     );
   }
 
+  getRights(): string | null {
+    return this.getProperty("rights");
+  }
+
   getNavDate(): Date {
     return new Date(this.getProperty("navDate"));
   }

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -87,7 +87,7 @@ export class IIIFResource extends ManifestResource {
         return null;
       }
 
-      logo = provider.logo;
+      logo = provider[0].logo;
     }
 
     if (!logo) return null;

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,7 @@ importTest('rijksmuseum-image-api-v3-thumbnails', './tests/rijksmuseum-image-api
 // importTest('items-not-sequence', './tests/items-not-sequence');
 // importTest('LabelValuePair', './tests/LabelValuePair.test');
 // importTest('LanguageMap', './tests/LanguageMap.test');
-// importTest('logo', './tests/logo');
+importTest('logo', './tests/logo');
 // importTest('lunchroommanners', './tests/lunchroommanners');
 // importTest('manifest-with-thumbnail', './tests/manifest-with-thumbnail');
 // importTest('members-collection', './tests/members-collection');
@@ -75,7 +75,7 @@ importTest('rijksmuseum-image-api-v3-thumbnails', './tests/rijksmuseum-image-api
 // importTest('pres3-collection3', './tests/pres3-collection3');
 // importTest('pres3-collection4', './tests/pres3-collection4');
 // importTest('pres3-pdf', './tests/pres3-pdf');
-// importTest('pres3', './tests/pres3');
+importTest('pres3', './tests/pres3');
 // importTest('presentation2-paging', './tests/presentation2-paging');
 // importTest('presentation3-paging', './tests/presentation3-paging');
 // importTest('PropertyValue', './tests/PropertyValue.test')

--- a/test/tests/pres3.js
+++ b/test/tests/pres3.js
@@ -46,4 +46,14 @@ describe('presentation 3', function() {
         var labelValue = label.getValue();
         expect(labelValue).to.equal('Page 1');
     });
+
+    it('has a logo', function () {
+        var logo = manifest.getLogo();
+        expect(logo).to.equal('https://example.org/logos/institution1.jpg');
+    });
+
+    it('has a rights', function () {
+        var rights = manifest.getRights();
+        expect(rights).to.equal('http://example.org/license.html');
+    });
 });


### PR DESCRIPTION
Adding a getRights method, and fixing the getLogo method to get metadata from v3 manifests. This will allow subsequent changes to manifold and iiif-metadata-component that will address the issue of v3 manifest metadata not appearing the the UV metadata panel: https://github.com/UniversalViewer/universalviewer/issues/973