### PR TITLE
fix: maxWidth coalescence

### DIFF
--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -170,7 +170,7 @@ export class Canvas extends Resource {
       profile = this.externalResource.data.profile;
 
       if (Array.isArray(profile)) {
-        profile = profile.filter(p => p["maxWidth" || "maxwidth"])[0];
+        profile = profile.filter(p => p["maxWidth"] ?? p["maxwidth"])[0];
 
         if (profile) {
           maxDimensions = new Size(


### PR DESCRIPTION
`"maxWidth" || "maxwidth"` is just "maxWidth" with extra steps.

- [ ] Needs a test