### PR TITLE
fixes getLogo for Providers with no Logo

### DIFF
--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -89,7 +89,11 @@ export class IIIFResource extends ManifestResource {
 
       // get the first agent in the provider array with a logo
       const agent = provider.find(item => item.logo !== undefined);
-      logo = typeof agent.logo === "undefined" ? null : agent.logo;
+      if (agent && agent.logo !== undefined) {
+        logo = agent.logo;
+      } else {
+        logo = null;
+      }
     }
 
     if (!logo) return null;

--- a/test/fixtures/YaleCanterburyTalesV3ProviderNoLogo.json
+++ b/test/fixtures/YaleCanterburyTalesV3ProviderNoLogo.json
@@ -1,0 +1,17137 @@
+{
+  "@context": [
+    "http://iiif.io/api/search/1/context.json",
+    "http://iiif.io/api/extension/navplace/context.json",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  "id": "https://collections.library.yale.edu/manifests/16371215",
+  "type": "Manifest",
+  "label": {
+    "none": ["Canterbury tales"]
+  },
+  "homepage": [
+    {
+      "id": "https://collections.library.yale.edu/catalog/16371215",
+      "type": "Text",
+      "format": "text/html",
+      "label": {
+        "en": ["Yale Digital Collections page"]
+      }
+    }
+  ],
+  "requiredStatement": {
+    "label": {
+      "en": ["Provider"]
+    },
+    "value": {
+      "en": ["Yale University Library"]
+    }
+  },
+  "rendering": [
+    {
+      "id": "https://collections.library.yale.edu/pdfs/16371215.pdf",
+      "type": "Text",
+      "format": "application/pdf",
+      "label": {
+        "en": ["Download as PDF"]
+      }
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https://collections.library.yale.edu/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=oai:collections.library.yale.edu:16371215",
+      "type": "Dataset",
+      "format": "application/mods+xml",
+      "profile": "http://www.loc.gov/mods/v3"
+    }
+  ],
+  "metadata": [
+    {
+      "label": {
+        "en": ["Alternative Title"]
+      },
+      "value": {
+        "none": ["Sion College Chaucer"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Creator"]
+      },
+      "value": {
+        "none": ["Chaucer, Geoffrey, -1400"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Published/Created Date"]
+      },
+      "value": {
+        "none": ["[ca. 1460-1490]"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Publication Place"]
+      },
+      "value": {
+        "none": ["England"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Abstract"]
+      },
+      "value": {
+        "none": [
+          "Manuscript, on parchment, in a single hand, containing four of the Canterbury tales: the Clerk's tale; the Wife of Bath's tale; the Friar's tale; and the Summoner's tale"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Description"]
+      },
+      "value": {
+        "none": [
+          "In Middle English.",
+          "Annotated on f. 78 with the names \"William Cooke\" and \"Morris Barckley.\"",
+          "Layout: single columns of 24 lines.",
+          "Script: English bookhand.",
+          "Decoration: six initials in red.",
+          "Library stamp: Sion College.",
+          "Binding: twenty-first-century conservation binding.",
+          "Earlier binding: eighteenth-century full paneled calf, gilt (stored in box 2)"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Provenance"]
+      },
+      "value": {
+        "none": [
+          "Formerly owned by Henry R. Grissil. Formerly owned by William Cooke. Formerly owned by Sir Maurice Berkeley. Ex libris Sion College Library. Purchased from Toshiyuki Takamiya on the Edwin J. Beinecke Book Fund, 2017."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Extent"]
+      },
+      "value": {
+        "none": ["79 leaves : 215 mm x 160 mm"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Language"]
+      },
+      "value": {
+        "none": ["English, Middle (1100-1500)"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Repository"]
+      },
+      "value": {
+        "none": ["Beinecke Library"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Call Number"]
+      },
+      "value": {
+        "none": ["Takamiya MS 22"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Container / Volume Information"]
+      },
+      "value": {
+        "none": ["Box 1"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Extent of Digitization"]
+      },
+      "value": {
+        "none": ["Completely digitized"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Genre"]
+      },
+      "value": {
+        "none": [
+          "Manuscripts, Medieval England 15th century",
+          "Medieval and Renaissance Manuscripts in Beinecke Library"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Material"]
+      },
+      "value": {
+        "none": ["parchment ;"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Resource Type"]
+      },
+      "value": {
+        "none": ["unspecified"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Subject (Geographic)"]
+      },
+      "value": {
+        "none": ["Connecticut", "New Haven.", "English poetry"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Subject (Name)"]
+      },
+      "value": {
+        "none": ["Chaucer, Geoffrey, -1400."]
+      }
+    },
+    {
+      "label": {
+        "en": ["Subject (Topic)"]
+      },
+      "value": {
+        "none": ["Manuscripts, Medieval", "English literature"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Access"]
+      },
+      "value": {
+        "none": ["Public"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Rights"]
+      },
+      "value": {
+        "none": [
+          "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Citation"]
+      },
+      "value": {
+        "none": [
+          "Geoffrey Chaucer, Canterbury Tales (Takamiya MS 22). General Collection, Beinecke Rare Book and Manuscript Library, Yale University."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Orbis ID"]
+      },
+      "value": {
+        "none": ["11713846"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Object ID (OID)"]
+      },
+      "value": {
+        "none": ["16371215"]
+      }
+    }
+  ],
+  "provider": [
+    {
+      "id": "https://www.wikidata.org/wiki/Q2583293",
+      "type": "Agent",
+      "label": {
+        "en": ["Yale Library"]
+      },
+      "homepage": [
+        {
+          "id": "https://library.yale.edu/",
+          "type": "Text",
+          "label": {
+            "en": ["Yale Library homepage"]
+          },
+          "format": "text/html"
+        }
+      ]
+    }
+  ],
+  "viewingDirection": "left-to-right",
+  "behavior": ["paged"],
+  "items": [
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395012/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395012/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395012",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395012/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3616,
+                "width": 2792,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395012",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395012",
+      "label": {
+        "none": ["[Front cover]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395012/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 232,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395012",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395012/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395012",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3616,
+      "width": 2792,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395012"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[Front cover]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395012"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395013/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395013/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395013",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395013/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3629,
+                "width": 2782,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395013",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395013",
+      "label": {
+        "none": ["[Front pastedown]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395013/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 230,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395013",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395013/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395013",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3629,
+      "width": 2782,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395013"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[Front pastedown]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395013"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395004/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395004/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395004",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395004/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3576,
+                "width": 2744,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395004",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395004",
+      "label": {
+        "none": ["[i]r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395004/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 230,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395004",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395004/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395004",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3576,
+      "width": 2744,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395004"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[i]r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395004"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395005/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395005/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395005",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395005/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3536,
+                "width": 2846,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395005",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395005",
+      "label": {
+        "none": ["[i]v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395005/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395005",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395005/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395005",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3536,
+      "width": 2846,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395005"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[i]v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395005"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395006/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395006/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395006",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395006/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3548,
+                "width": 2800,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395006",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395006",
+      "label": {
+        "none": ["[ii]r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395006/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 237,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395006",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395006/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395006",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3548,
+      "width": 2800,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395006"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[ii]r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395006"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395007/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395007/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395007",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395007/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3538,
+                "width": 2754,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395007",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395007",
+      "label": {
+        "none": ["[ii]v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395007/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 234,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395007",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395007/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395007",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3538,
+      "width": 2754,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395007"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[ii]v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395007"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395008/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395008/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395008",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395008/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3640,
+                "width": 3088,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395008",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395008",
+      "label": {
+        "none": ["[iii]r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395008/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 255,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395008",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395008/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395008",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3640,
+      "width": 3088,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395008"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[iii]r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395008"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395009/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395009/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395009",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395009/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3538,
+                "width": 2803,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395009",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395009",
+      "label": {
+        "none": ["[iii]v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395009/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395009",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395009/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395009",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3538,
+      "width": 2803,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395009"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[iii]v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395009"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395010/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395010/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395010",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395010/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3542,
+                "width": 2715,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395010",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395010",
+      "label": {
+        "none": ["[iv]r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395010/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 230,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395010",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395010/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395010",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3542,
+      "width": 2715,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395010"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[iv]r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395010"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395011/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395011/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395011",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395011/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3566,
+                "width": 2761,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395011",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395011",
+      "label": {
+        "none": ["[iv]v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395011/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 232,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395011",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395011/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395011",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3566,
+      "width": 2761,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395011"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[iv]v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395011"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394846/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394846/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394846",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394846/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3520,
+                "width": 2816,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394846",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394846",
+      "label": {
+        "none": ["1r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394846/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394846",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394846/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394846",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3520,
+      "width": 2816,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394846"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["1r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394846"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394847/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394847/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394847",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394847/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3440,
+                "width": 2774,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394847",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394847",
+      "label": {
+        "none": ["1v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394847/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394847",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394847/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394847",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3440,
+      "width": 2774,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394847"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["1v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394847"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394848/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394848/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394848",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394848/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2860,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394848",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394848",
+      "label": {
+        "none": ["2r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394848/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394848",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394848/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394848",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2860,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394848"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["2r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394848"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394849/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394849/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394849",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394849/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3458,
+                "width": 2810,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394849",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394849",
+      "label": {
+        "none": ["2v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394849/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394849",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394849/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394849",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3458,
+      "width": 2810,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394849"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["2v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394849"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394850/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394850/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394850",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394850/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3539,
+                "width": 2858,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394850",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394850",
+      "label": {
+        "none": ["3r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394850/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394850",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394850/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394850",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3539,
+      "width": 2858,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394850"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["3r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394850"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394851/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394851/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394851",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394851/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2822,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394851",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394851",
+      "label": {
+        "none": ["3v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394851/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394851",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394851/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394851",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2822,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394851"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["3v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394851"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394852/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394852/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394852",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394852/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2858,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394852",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394852",
+      "label": {
+        "none": ["[4r]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394852/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394852",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394852/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394852",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2858,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394852"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[4r]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394852"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394853/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394853/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394853",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394853/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2762,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394853",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394853",
+      "label": {
+        "none": ["[4v]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394853/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394853",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394853/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394853",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2762,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394853"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[4v]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394853"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394854/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394854/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394854",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394854/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2852,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394854",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394854",
+      "label": {
+        "none": ["[5r]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394854/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394854",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394854/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394854",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2852,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394854"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[5r]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394854"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394855/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394855/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394855",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394855/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2858,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394855",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394855",
+      "label": {
+        "none": ["[5v]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394855/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394855",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394855/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394855",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2858,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394855"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[5v]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394855"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394856/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394856/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394856",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394856/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2906,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394856",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394856",
+      "label": {
+        "none": ["[6r]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394856/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 248,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394856",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394856/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394856",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2906,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394856"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[6r]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394856"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394857/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394857/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394857",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394857/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2882,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394857",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394857",
+      "label": {
+        "none": ["[6v]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394857/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394857",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394857/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394857",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2882,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394857"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[6v]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394857"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394858/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394858/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394858",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394858/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2870,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394858",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394858",
+      "label": {
+        "none": ["7r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394858/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394858",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394858/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394858",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2870,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394858"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["7r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394858"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394859/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394859/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394859",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394859/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2870,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394859",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394859",
+      "label": {
+        "none": ["7v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394859/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394859",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394859/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394859",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2870,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394859"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["7v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394859"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394860/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394860/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394860",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394860/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3482,
+                "width": 2783,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394860",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394860",
+      "label": {
+        "none": ["8r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394860/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394860",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394860/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394860",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3482,
+      "width": 2783,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394860"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["8r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394860"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394861/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394861/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394861",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394861/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2798,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394861",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394861",
+      "label": {
+        "none": ["8v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394861/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394861",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394861/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394861",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2798,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394861"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["8v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394861"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394862/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394862/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394862",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394862/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2768,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394862",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394862",
+      "label": {
+        "none": ["9r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394862/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 236,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394862",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394862/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394862",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2768,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394862"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["9r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394862"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394863/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394863/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394863",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394863/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3482,
+                "width": 2912,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394863",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394863",
+      "label": {
+        "none": ["9v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394863/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 251,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394863",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394863/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394863",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3482,
+      "width": 2912,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394863"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["9v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394863"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394864/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394864/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394864",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394864/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2936,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394864",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394864",
+      "label": {
+        "none": ["10r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394864/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 251,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394864",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394864/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394864",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2936,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394864"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["10r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394864"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394865/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394865/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394865",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394865/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2882,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394865",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394865",
+      "label": {
+        "none": ["10v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394865/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394865",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394865/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394865",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2882,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394865"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["10v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394865"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394866/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394866/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394866",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394866/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2852,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394866",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394866",
+      "label": {
+        "none": ["11r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394866/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394866",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394866/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394866",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2852,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394866"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["11r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394866"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394867/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394867/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394867",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394867/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2828,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394867",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394867",
+      "label": {
+        "none": ["11v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394867/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394867",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394867/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394867",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2828,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394867"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["11v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394867"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394868/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394868/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394868",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394868/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2936,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394868",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394868",
+      "label": {
+        "none": ["12r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394868/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 251,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394868",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394868/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394868",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2936,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394868"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["12r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394868"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394869/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394869/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394869",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394869/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2834,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394869",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394869",
+      "label": {
+        "none": ["12v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394869/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394869",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394869/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394869",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2834,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394869"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["12v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394869"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394870/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394870/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394870",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394870/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2882,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394870",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394870",
+      "label": {
+        "none": ["13r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394870/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394870",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394870/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394870",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2882,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394870"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["13r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394870"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394871/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394871/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394871",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394871/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394871",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394871",
+      "label": {
+        "none": ["13v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394871/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394871",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394871/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394871",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394871"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["13v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394871"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394872/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394872/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394872",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394872/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2876,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394872",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394872",
+      "label": {
+        "none": ["14r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394872/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394872",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394872/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394872",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2876,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394872"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["14r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394872"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394873/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394873/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394873",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394873/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2906,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394873",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394873",
+      "label": {
+        "none": ["14v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394873/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 249,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394873",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394873/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394873",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2906,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394873"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["14v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394873"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394874/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394874/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394874",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394874/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2876,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394874",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394874",
+      "label": {
+        "none": ["15r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394874/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394874",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394874/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394874",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2876,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394874"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["15r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394874"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394875/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394875/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394875",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394875/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394875",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394875",
+      "label": {
+        "none": ["15v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394875/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 248,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394875",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394875/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394875",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394875"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["15v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394875"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394876/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394876/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394876",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394876/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394876",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394876",
+      "label": {
+        "none": ["16r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394876/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394876",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394876/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394876",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394876"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["16r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394876"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394877/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394877/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394877",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394877/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2756,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394877",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394877",
+      "label": {
+        "none": ["16v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394877/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 237,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394877",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394877/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394877",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2756,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394877"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["16v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394877"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394878/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394878/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394878",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394878/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3499,
+                "width": 2744,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394878",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394878",
+      "label": {
+        "none": ["17r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394878/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 235,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394878",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394878/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394878",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3499,
+      "width": 2744,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394878"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["17r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394878"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394879/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394879/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394879",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394879/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2814,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394879",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394879",
+      "label": {
+        "none": ["17v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394879/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394879",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394879/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394879",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2814,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394879"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["17v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394879"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394880/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394880/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394880",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394880/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2836,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394880",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394880",
+      "label": {
+        "none": ["18r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394880/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394880",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394880/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394880",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2836,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394880"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["18r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394880"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394881/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394881/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394881",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394881/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2800,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394881",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394881",
+      "label": {
+        "none": ["18v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394881/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394881",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394881/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394881",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2800,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394881"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["18v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394881"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394882/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394882/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394882",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394882/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2876,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394882",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394882",
+      "label": {
+        "none": ["19r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394882/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394882",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394882/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394882",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2876,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394882"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["19r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394882"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394883/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394883/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394883",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394883/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2846,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394883",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394883",
+      "label": {
+        "none": ["19v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394883/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394883",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394883/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394883",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2846,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394883"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["19v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394883"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394884/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394884/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394884",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394884/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2798,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394884",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394884",
+      "label": {
+        "none": ["20r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394884/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394884",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394884/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394884",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2798,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394884"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["20r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394884"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394885/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394885/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394885",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394885/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3548,
+                "width": 2862,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394885",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394885",
+      "label": {
+        "none": ["20v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394885/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394885",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394885/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394885",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3548,
+      "width": 2862,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394885"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["20v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394885"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394886/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394886/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394886",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394886/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394886",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394886",
+      "label": {
+        "none": ["21r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394886/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394886",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394886/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394886",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394886"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["21r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394886"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394887/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394887/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394887",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394887/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2948,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394887",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394887",
+      "label": {
+        "none": ["21v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394887/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 251,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394887",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394887/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394887",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2948,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394887"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["21v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394887"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394888/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394888/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394888",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394888/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2852,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394888",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394888",
+      "label": {
+        "none": ["22r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394888/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394888",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394888/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394888",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2852,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394888"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["22r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394888"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394889/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394889/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394889",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394889/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394889",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394889",
+      "label": {
+        "none": ["22v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394889/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394889",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394889/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394889",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394889"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["22v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394889"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394890/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394890/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394890",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394890/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2806,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394890",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394890",
+      "label": {
+        "none": ["23r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394890/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394890",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394890/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394890",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2806,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394890"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["23r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394890"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394891/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394891/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394891",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394891/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2966,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394891",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394891",
+      "label": {
+        "none": ["23v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394891/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 252,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394891",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394891/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394891",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2966,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394891"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["23v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394891"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394892/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394892/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394892",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394892/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2876,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394892",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394892",
+      "label": {
+        "none": ["24r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394892/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394892",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394892/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394892",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2876,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394892"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["24r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394892"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394893/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394893/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394893",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394893/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3472,
+                "width": 2743,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394893",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394893",
+      "label": {
+        "none": ["24v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394893/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 237,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394893",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394893/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394893",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3472,
+      "width": 2743,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394893"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["24v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394893"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394894/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394894/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394894",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394894/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3560,
+                "width": 2798,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394894",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394894",
+      "label": {
+        "none": ["25r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394894/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 236,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394894",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394894/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394894",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3560,
+      "width": 2798,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394894"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["25r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394894"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394895/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394895/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394895",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394895/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3482,
+                "width": 2847,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394895",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394895",
+      "label": {
+        "none": ["25v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394895/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394895",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394895/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394895",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3482,
+      "width": 2847,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394895"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["25v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394895"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394896/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394896/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394896",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394896/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3548,
+                "width": 2888,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394896",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394896",
+      "label": {
+        "none": ["26r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394896/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394896",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394896/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394896",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3548,
+      "width": 2888,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394896"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["26r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394896"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394897/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394897/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394897",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394897/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2858,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394897",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394897",
+      "label": {
+        "none": ["26v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394897/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394897",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394897/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394897",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2858,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394897"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["26v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394897"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394898/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394898/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394898",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394898/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3560,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394898",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394898",
+      "label": {
+        "none": ["27r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394898/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394898",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394898/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394898",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3560,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394898"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["27r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394898"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394899/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394899/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394899",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394899/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3554,
+                "width": 2870,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394899",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394899",
+      "label": {
+        "none": ["27v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394899/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394899",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394899/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394899",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3554,
+      "width": 2870,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394899"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["27v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394899"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394900/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394900/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394900",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394900/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3536,
+                "width": 2834,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394900",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394900",
+      "label": {
+        "none": ["28r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394900/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394900",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394900/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394900",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3536,
+      "width": 2834,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394900"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["28r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394900"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394901/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394901/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394901",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394901/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2930,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394901",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394901",
+      "label": {
+        "none": ["28v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394901/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 251,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394901",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394901/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394901",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2930,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394901"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["28v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394901"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394902/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394902/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394902",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394902/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3542,
+                "width": 2812,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394902",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394902",
+      "label": {
+        "none": ["29r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394902/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394902",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394902/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394902",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3542,
+      "width": 2812,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394902"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["29r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394902"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394903/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394903/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394903",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394903/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3578,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394903",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394903",
+      "label": {
+        "none": ["29v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394903/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394903",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394903/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394903",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3578,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394903"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["29v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394903"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394904/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394904/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394904",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394904/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2888,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394904",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394904",
+      "label": {
+        "none": ["30r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394904/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394904",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394904/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394904",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2888,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394904"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["30r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394904"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394905/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394905/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394905",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394905/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3572,
+                "width": 2918,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394905",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394905",
+      "label": {
+        "none": ["30v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394905/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394905",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394905/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394905",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3572,
+      "width": 2918,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394905"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["30v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394905"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394906/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394906/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394906",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394906/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2900,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394906",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394906",
+      "label": {
+        "none": ["31r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394906/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394906",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394906/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394906",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2900,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394906"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["31r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394906"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394907/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394907/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394907",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394907/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3560,
+                "width": 2870,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394907",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394907",
+      "label": {
+        "none": ["31v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394907/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394907",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394907/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394907",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3560,
+      "width": 2870,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394907"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["31v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394907"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394908/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394908/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394908",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394908/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2828,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394908",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394908",
+      "label": {
+        "none": ["32r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394908/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394908",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394908/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394908",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2828,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394908"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["32r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394908"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394909/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394909/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394909",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394909/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2816,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394909",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394909",
+      "label": {
+        "none": ["32v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394909/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394909",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394909/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394909",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2816,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394909"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["32v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394909"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394910/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394910/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394910",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394910/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2798,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394910",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394910",
+      "label": {
+        "none": ["33r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394910/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394910",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394910/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394910",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2798,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394910"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["33r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394910"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394911/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394911/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394911",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394911/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2810,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394911",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394911",
+      "label": {
+        "none": ["33v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394911/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394911",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394911/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394911",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2810,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394911"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["33v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394911"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394912/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394912/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394912",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394912/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2930,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394912",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394912",
+      "label": {
+        "none": ["34r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394912/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 249,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394912",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394912/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394912",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2930,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394912"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["34r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394912"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394913/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394913/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394913",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394913/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2840,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394913",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394913",
+      "label": {
+        "none": ["34v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394913/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394913",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394913/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394913",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2840,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394913"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["34v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394913"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394914/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394914/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394914",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394914/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2848,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394914",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394914",
+      "label": {
+        "none": ["35r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394914/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394914",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394914/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394914",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2848,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394914"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["35r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394914"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394915/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394915/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394915",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394915/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2805,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394915",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394915",
+      "label": {
+        "none": ["35v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394915/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394915",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394915/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394915",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2805,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394915"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["35v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394915"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394916/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394916/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394916",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394916/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3566,
+                "width": 2870,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394916",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394916",
+      "label": {
+        "none": ["36r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394916/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394916",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394916/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394916",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3566,
+      "width": 2870,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394916"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["36r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394916"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394917/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394917/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394917",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394917/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2804,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394917",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394917",
+      "label": {
+        "none": ["36v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394917/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394917",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394917/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394917",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2804,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394917"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["36v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394917"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394918/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394918/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394918",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394918/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3566,
+                "width": 2798,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394918",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394918",
+      "label": {
+        "none": ["37r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394918/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 235,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394918",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394918/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394918",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3566,
+      "width": 2798,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394918"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["37r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394918"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394919/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394919/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394919",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394919/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394919",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394919",
+      "label": {
+        "none": ["37v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394919/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394919",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394919/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394919",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394919"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["37v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394919"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394920/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394920/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394920",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394920/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2774,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394920",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394920",
+      "label": {
+        "none": ["38r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394920/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 236,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394920",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394920/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394920",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2774,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394920"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["38r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394920"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394921/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394921/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394921",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394921/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2900,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394921",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394921",
+      "label": {
+        "none": ["38v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394921/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394921",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394921/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394921",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2900,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394921"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["38v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394921"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394922/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394922/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394922",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394922/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2822,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394922",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394922",
+      "label": {
+        "none": ["39r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394922/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394922",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394922/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394922",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2822,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394922"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["39r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394922"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394923/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394923/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394923",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394923/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2826,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394923",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394923",
+      "label": {
+        "none": ["39v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394923/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394923",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394923/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394923",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2826,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394923"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["39v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394923"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394924/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394924/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394924",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394924/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2771,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394924",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394924",
+      "label": {
+        "none": ["40r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394924/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 237,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394924",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394924/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394924",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2771,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394924"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["40r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394924"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394925/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394925/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394925",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394925/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2780,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394925",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394925",
+      "label": {
+        "none": ["40v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394925/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394925",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394925/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394925",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2780,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394925"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["40v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394925"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394926/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394926/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394926",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394926/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2762,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394926",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394926",
+      "label": {
+        "none": ["41r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394926/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 235,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394926",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394926/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394926",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2762,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394926"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["41r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394926"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394927/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394927/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394927",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394927/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3482,
+                "width": 2796,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394927",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394927",
+      "label": {
+        "none": ["41v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394927/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394927",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394927/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394927",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3482,
+      "width": 2796,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394927"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["41v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394927"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394928/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394928/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394928",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394928/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2852,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394928",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394928",
+      "label": {
+        "none": ["42r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394928/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394928",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394928/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394928",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2852,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394928"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["42r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394928"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394929/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394929/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394929",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394929/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3476,
+                "width": 2840,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394929",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394929",
+      "label": {
+        "none": ["42v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394929/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394929",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394929/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394929",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3476,
+      "width": 2840,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394929"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["42v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394929"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394930/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394930/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394930",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394930/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2856,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394930",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394930",
+      "label": {
+        "none": ["43r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394930/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394930",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394930/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394930",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2856,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394930"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["43r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394930"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394931/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394931/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394931",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394931/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2858,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394931",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394931",
+      "label": {
+        "none": ["43v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394931/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394931",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394931/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394931",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2858,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394931"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["43v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394931"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394932/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394932/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394932",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394932/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2836,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394932",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394932",
+      "label": {
+        "none": ["44r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394932/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394932",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394932/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394932",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2836,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394932"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["44r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394932"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394933/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394933/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394933",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394933/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2824,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394933",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394933",
+      "label": {
+        "none": ["44v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394933/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394933",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394933/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394933",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2824,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394933"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["44v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394933"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394934/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394934/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394934",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394934/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2810,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394934",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394934",
+      "label": {
+        "none": ["45r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394934/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394934",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394934/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394934",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2810,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394934"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["45r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394934"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394935/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394935/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394935",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394935/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2839,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394935",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394935",
+      "label": {
+        "none": ["45v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394935/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394935",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394935/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394935",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2839,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394935"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["45v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394935"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394936/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394936/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394936",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394936/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2846,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394936",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394936",
+      "label": {
+        "none": ["46r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394936/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394936",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394936/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394936",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2846,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394936"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["46r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394936"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394937/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394937/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394937",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394937/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2909,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394937",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394937",
+      "label": {
+        "none": ["46v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394937/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394937",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394937/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394937",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2909,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394937"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["46v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394937"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394938/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394938/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394938",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394938/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2794,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394938",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394938",
+      "label": {
+        "none": ["47r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394938/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394938",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394938/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394938",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2794,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394938"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["47r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394938"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394939/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394939/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394939",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394939/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3542,
+                "width": 2904,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394939",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394939",
+      "label": {
+        "none": ["47v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394939/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394939",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394939/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394939",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3542,
+      "width": 2904,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394939"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["47v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394939"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394940/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394940/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394940",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394940/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2801,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394940",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394940",
+      "label": {
+        "none": ["48r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394940/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394940",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394940/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394940",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2801,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394940"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["48r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394940"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394941/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394941/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394941",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394941/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2780,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394941",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394941",
+      "label": {
+        "none": ["48v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394941/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394941",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394941/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394941",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2780,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394941"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["48v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394941"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394942/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394942/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394942",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394942/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2816,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394942",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394942",
+      "label": {
+        "none": ["49r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394942/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394942",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394942/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394942",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2816,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394942"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["49r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394942"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394943/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394943/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394943",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394943/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2858,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394943",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394943",
+      "label": {
+        "none": ["49v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394943/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394943",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394943/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394943",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2858,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394943"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["49v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394943"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394944/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394944/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394944",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394944/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394944",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394944",
+      "label": {
+        "none": ["50r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394944/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 248,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394944",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394944/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394944",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394944"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["50r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394944"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394945/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394945/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394945",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394945/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3500,
+                "width": 2824,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394945",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394945",
+      "label": {
+        "none": ["50v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394945/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394945",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394945/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394945",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3500,
+      "width": 2824,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394945"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["50v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394945"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394946/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394946/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394946",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394946/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2834,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394946",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394946",
+      "label": {
+        "none": ["51r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394946/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394946",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394946/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394946",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2834,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394946"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["51r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394946"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394947/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394947/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394947",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394947/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2852,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394947",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394947",
+      "label": {
+        "none": ["51v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394947/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394947",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394947/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394947",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2852,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394947"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["51v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394947"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394948/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394948/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394948",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394948/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2906,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394948",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394948",
+      "label": {
+        "none": ["52r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394948/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 247,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394948",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394948/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394948",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2906,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394948"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["52r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394948"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394949/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394949/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394949",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394949/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2810,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394949",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394949",
+      "label": {
+        "none": ["52v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394949/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394949",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394949/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394949",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2810,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394949"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["52v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394949"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394950/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394950/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394950",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394950/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2831,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394950",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394950",
+      "label": {
+        "none": ["53r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394950/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394950",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394950/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394950",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2831,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394950"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["53r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394950"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394951/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394951/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394951",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394951/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2840,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394951",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394951",
+      "label": {
+        "none": ["53v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394951/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394951",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394951/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394951",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2840,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394951"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["53v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394951"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394952/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394952/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394952",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394952/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3542,
+                "width": 2835,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394952",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394952",
+      "label": {
+        "none": ["54r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394952/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394952",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394952/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394952",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3542,
+      "width": 2835,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394952"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["54r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394952"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394953/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394953/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394953",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394953/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3494,
+                "width": 2912,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394953",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394953",
+      "label": {
+        "none": ["54v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394953/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 250,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394953",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394953/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394953",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3494,
+      "width": 2912,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394953"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["54v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394953"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394954/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394954/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394954",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394954/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2838,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394954",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394954",
+      "label": {
+        "none": ["55r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394954/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394954",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394954/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394954",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2838,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394954"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["55r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394954"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394955/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394955/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394955",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394955/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394955",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394955",
+      "label": {
+        "none": ["55v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394955/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394955",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394955/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394955",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394955"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["55v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394955"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394956/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394956/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394956",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394956/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3482,
+                "width": 2788,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394956",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394956",
+      "label": {
+        "none": ["56r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394956/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394956",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394956/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394956",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3482,
+      "width": 2788,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394956"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["56r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394956"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394957/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394957/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394957",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394957/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3512,
+                "width": 2786,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394957",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394957",
+      "label": {
+        "none": ["56v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394957/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394957",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394957/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394957",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3512,
+      "width": 2786,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394957"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["56v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394957"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394958/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394958/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394958",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394958/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2786,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394958",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394958",
+      "label": {
+        "none": ["57r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394958/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394958",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394958/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394958",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2786,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394958"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["57r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394958"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394959/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394959/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394959",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394959/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3464,
+                "width": 2840,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394959",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394959",
+      "label": {
+        "none": ["57v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394959/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394959",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394959/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394959",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3464,
+      "width": 2840,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394959"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["57v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394959"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394960/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394960/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394960",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394960/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3554,
+                "width": 2882,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394960",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394960",
+      "label": {
+        "none": ["58r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394960/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394960",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394960/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394960",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3554,
+      "width": 2882,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394960"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["58r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394960"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394961/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394961/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394961",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394961/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3488,
+                "width": 2828,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394961",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394961",
+      "label": {
+        "none": ["58v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394961/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394961",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394961/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394961",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3488,
+      "width": 2828,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394961"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["58v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394961"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394962/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394962/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394962",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394962/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3536,
+                "width": 2897,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394962",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394962",
+      "label": {
+        "none": ["59r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394962/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394962",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394962/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394962",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3536,
+      "width": 2897,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394962"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["59r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394962"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394963/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394963/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394963",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394963/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3470,
+                "width": 2829,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394963",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394963",
+      "label": {
+        "none": ["59v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394963/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 245,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394963",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394963/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394963",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3470,
+      "width": 2829,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394963"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["59v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394963"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394964/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394964/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394964",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394964/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3566,
+                "width": 2854,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394964",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394964",
+      "label": {
+        "none": ["60r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394964/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394964",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394964/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394964",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3566,
+      "width": 2854,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394964"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["60r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394964"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394965/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394965/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394965",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394965/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3470,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394965",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394965",
+      "label": {
+        "none": ["60v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394965/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 248,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394965",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394965/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394965",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3470,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394965"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["60v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394965"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394966/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394966/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394966",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394966/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3560,
+                "width": 2846,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394966",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394966",
+      "label": {
+        "none": ["61r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394966/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394966",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394966/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394966",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3560,
+      "width": 2846,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394966"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["61r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394966"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394967/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394967/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394967",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394967/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2847,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394967",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394967",
+      "label": {
+        "none": ["61v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394967/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394967",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394967/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394967",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2847,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394967"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["61v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394967"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394968/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394968/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394968",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394968/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3554,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394968",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394968",
+      "label": {
+        "none": ["62r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394968/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394968",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394968/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394968",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3554,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394968"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["62r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394968"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394969/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394969/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394969",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394969/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3530,
+                "width": 2876,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394969",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394969",
+      "label": {
+        "none": ["62v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394969/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394969",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394969/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394969",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3530,
+      "width": 2876,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394969"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["62v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394969"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394970/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394970/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394970",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394970/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3554,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394970",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394970",
+      "label": {
+        "none": ["63r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394970/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394970",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394970/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394970",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3554,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394970"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["63r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394970"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394971/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394971/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394971",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394971/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2876,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394971",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394971",
+      "label": {
+        "none": ["63v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394971/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 246,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394971",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394971/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394971",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2876,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394971"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["63v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394971"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394972/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394972/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394972",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394972/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3506,
+                "width": 2822,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394972",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394972",
+      "label": {
+        "none": ["64r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394972/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394972",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394972/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394972",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3506,
+      "width": 2822,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394972"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["64r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394972"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394973/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394973/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394973",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394973/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3554,
+                "width": 2846,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394973",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394973",
+      "label": {
+        "none": ["64v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394973/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394973",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394973/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394973",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3554,
+      "width": 2846,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394973"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["64v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394973"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394974/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394974/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394974",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394974/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3518,
+                "width": 2780,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394974",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394974",
+      "label": {
+        "none": ["65r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394974/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 237,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394974",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394974/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394974",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3518,
+      "width": 2780,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394974"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["65r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394974"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394975/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394975/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394975",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394975/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3496,
+                "width": 2768,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394975",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394975",
+      "label": {
+        "none": ["65v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394975/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394975",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394975/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394975",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3496,
+      "width": 2768,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394975"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["65v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394975"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394976/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394976/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394976",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394976/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3510,
+                "width": 2929,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394976",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394976",
+      "label": {
+        "none": ["66r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394976/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 250,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394976",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394976/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394976",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3510,
+      "width": 2929,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394976"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["66r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394976"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394977/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394977/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394977",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394977/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3496,
+                "width": 2824,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394977",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394977",
+      "label": {
+        "none": ["66v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394977/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394977",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394977/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394977",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3496,
+      "width": 2824,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394977"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["66v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394977"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394978/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394978/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394978",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394978/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3510,
+                "width": 2852,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394978",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394978",
+      "label": {
+        "none": ["67r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394978/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394978",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394978/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394978",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3510,
+      "width": 2852,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394978"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["67r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394978"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394979/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394979/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394979",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394979/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3517,
+                "width": 2820,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394979",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394979",
+      "label": {
+        "none": ["67v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394979/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394979",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394979/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394979",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3517,
+      "width": 2820,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394979"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["67v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394979"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394980/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394980/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394980",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394980/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3559,
+                "width": 2880,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394980",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394980",
+      "label": {
+        "none": ["68r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394980/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394980",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394980/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394980",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3559,
+      "width": 2880,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394980"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["68r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394980"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394981/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394981/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394981",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394981/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3510,
+                "width": 2807,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394981",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394981",
+      "label": {
+        "none": ["68v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394981/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394981",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394981/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394981",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3510,
+      "width": 2807,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394981"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["68v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394981"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394982/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394982/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394982",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394982/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3538,
+                "width": 2828,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394982",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394982",
+      "label": {
+        "none": ["69r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394982/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394982",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394982/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394982",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3538,
+      "width": 2828,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394982"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["69r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394982"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394983/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394983/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394983",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394983/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3559,
+                "width": 2819,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394983",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394983",
+      "label": {
+        "none": ["69v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394983/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394983",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394983/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394983",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3559,
+      "width": 2819,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394983"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["69v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394983"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394984/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394984/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394984",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394984/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3517,
+                "width": 2800,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394984",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394984",
+      "label": {
+        "none": ["70r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394984/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394984",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394984/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394984",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3517,
+      "width": 2800,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394984"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["70r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394984"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394985/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394985/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394985",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394985/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3489,
+                "width": 2894,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394985",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394985",
+      "label": {
+        "none": ["70v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394985/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 249,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394985",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394985/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394985",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3489,
+      "width": 2894,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394985"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["70v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394985"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394986/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394986/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394986",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394986/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3496,
+                "width": 2798,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394986",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394986",
+      "label": {
+        "none": ["71r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394986/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 240,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394986",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394986/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394986",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3496,
+      "width": 2798,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394986"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["71r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394986"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394987/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394987/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394987",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394987/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3503,
+                "width": 2901,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394987",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394987",
+      "label": {
+        "none": ["71v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394987/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 248,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394987",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394987/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394987",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3503,
+      "width": 2901,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394987"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["71v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394987"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394988/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394988/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394988",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394988/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3503,
+                "width": 2845,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394988",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394988",
+      "label": {
+        "none": ["72r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394988/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 244,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394988",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394988/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394988",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3503,
+      "width": 2845,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394988"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["72r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394988"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394989/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394989/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394989",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394989/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3517,
+                "width": 2803,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394989",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394989",
+      "label": {
+        "none": ["72v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394989/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394989",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394989/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394989",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3517,
+      "width": 2803,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394989"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["72v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394989"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394990/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394990/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394990",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394990/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3503,
+                "width": 2740,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394990",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394990",
+      "label": {
+        "none": ["73r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394990/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 235,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394990",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394990/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394990",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3503,
+      "width": 2740,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394990"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["73r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394990"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394991/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394991/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394991",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394991/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3496,
+                "width": 2747,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394991",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394991",
+      "label": {
+        "none": ["73v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394991/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 236,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394991",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394991/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394991",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3496,
+      "width": 2747,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394991"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["73v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394991"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394992/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394992/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394992",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394992/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3517,
+                "width": 2740,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394992",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394992",
+      "label": {
+        "none": ["74r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394992/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 234,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394992",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394992/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394992",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3517,
+      "width": 2740,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394992"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["74r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394992"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394993/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394993/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394993",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394993/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3475,
+                "width": 2814,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394993",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394993",
+      "label": {
+        "none": ["74v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394993/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394993",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394993/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394993",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3475,
+      "width": 2814,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394993"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["74v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394993"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394994/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394994/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394994",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394994/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3538,
+                "width": 2840,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394994",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394994",
+      "label": {
+        "none": ["75r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394994/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394994",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394994/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394994",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3538,
+      "width": 2840,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394994"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["75r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394994"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394995/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394995/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394995",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394995/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3482,
+                "width": 2797,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394995",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394995",
+      "label": {
+        "none": ["75v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394995/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394995",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394995/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394995",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3482,
+      "width": 2797,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394995"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["75v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394995"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394996/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394996/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394996",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394996/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3566,
+                "width": 2859,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394996",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394996",
+      "label": {
+        "none": ["76r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394996/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394996",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394996/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394996",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3566,
+      "width": 2859,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394996"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["76r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394996"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394997/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394997/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394997",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394997/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3503,
+                "width": 2796,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394997",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394997",
+      "label": {
+        "none": ["76v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394997/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 239,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394997",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394997/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394997",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3503,
+      "width": 2796,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394997"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["76v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394997"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394998/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394998/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394998",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394998/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3524,
+                "width": 2826,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394998",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394998",
+      "label": {
+        "none": ["77r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394998/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 241,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394998",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394998/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394998",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3524,
+      "width": 2826,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394998"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["77r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394998"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394999/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394999/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394999",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16394999/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3538,
+                "width": 2809,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16394999",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16394999",
+      "label": {
+        "none": ["77v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394999/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 238,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16394999",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16394999/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16394999",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3538,
+      "width": 2809,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16394999"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["77v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16394999"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395000/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395000/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395000",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395000/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3496,
+                "width": 2835,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395000",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395000",
+      "label": {
+        "none": ["78r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395000/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395000",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395000/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395000",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3496,
+      "width": 2835,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395000"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["78r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395000"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395001/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395001/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395001",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395001/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3531,
+                "width": 2864,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395001",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395001",
+      "label": {
+        "none": ["78v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395001/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 243,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395001",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395001/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395001",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3531,
+      "width": 2864,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395001"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["78v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395002/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395002/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395002",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395002/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3503,
+                "width": 2828,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395002",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395002",
+      "label": {
+        "none": ["[79]r"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395002/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 242,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395002",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395002/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395002",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3503,
+      "width": 2828,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395002"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[79]r"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395002"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395003/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395003/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395003",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395003/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3503,
+                "width": 2747,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395003",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395003",
+      "label": {
+        "none": ["[79]v"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395003/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 235,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395003",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395003/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395003",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3503,
+      "width": 2747,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395003"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[79]v"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395003"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395014/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395014/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395014",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395014/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3632,
+                "width": 2824,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395014",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395014",
+      "label": {
+        "none": ["[Back pastedown]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395014/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 233,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395014",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395014/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395014",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3632,
+      "width": 2824,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395014"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[Back pastedown]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395014"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "Canvas",
+      "items": [
+        {
+          "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395015/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395015/image/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395015",
+              "body": {
+                "id": "https://collections.library.yale.edu/iiif/2/16395015/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3635,
+                "width": 2843,
+                "service": [
+                  {
+                    "@id": "https://collections.library.yale.edu/iiif/2/16395015",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395015",
+      "label": {
+        "none": ["[Back cover]"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395015/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 235,
+          "service": [
+            {
+              "@id": "https://collections.library.yale.edu/iiif/2/16395015",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "rendering": [
+        {
+          "id": "https://collections.library.yale.edu/iiif/2/16395015/full/full/0/default.jpg",
+          "label": {
+            "en": ["Full size"]
+          },
+          "type": "Image",
+          "format": "image/jpeg"
+        },
+        {
+          "id": "https://collections.library.yale.edu/download/tiff/16395015",
+          "label": {
+            "en": ["Full size original"]
+          },
+          "type": "Image",
+          "format": "image/tiff"
+        }
+      ],
+      "height": 3635,
+      "width": 2843,
+      "metadata": [
+        {
+          "label": {
+            "en": ["Image ID"]
+          },
+          "value": {
+            "none": ["16395015"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Image Label"]
+          },
+          "value": {
+            "none": ["[Back cover]"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to this Image"]
+          },
+          "value": {
+            "none": [
+              "https://collections.library.yale.edu/catalog/16371215?child_oid=16395015"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https://collections.library.yale.edu/iiif/2/16395012/full/!300,300/0/default.jpg",
+      "type": "Image",
+      "format": "image/jpeg",
+      "height": 300,
+      "width": 232,
+      "service": [
+        {
+          "@id": "https://collections.library.yale.edu/iiif/2/16395012",
+          "@type": "ImageService2",
+          "profile": "http://iiif.io/api/image/2/level2.json"
+        }
+      ]
+    }
+  ],
+  "start": {
+    "id": "https://collections.library.yale.edu/manifests/oid/16371215/canvas/16395012",
+    "type": "Canvas"
+  },
+  "structures": [],
+  "navDate": "1460-01-01T00:00:00Z"
+}

--- a/test/fixtures/manifests.js
+++ b/test/fixtures/manifests.js
@@ -60,7 +60,8 @@ module.exports = {
     "sctagracilis": "http://localhost:3001/sctagracilis.json",
     "riksmuseumimageapiv3thumbnails": "http://localhost:3001/riksmuseum-image-api-v3-thumbnails.json",
     //"query-bodleian": "http://iiif.bodleian.ox.ac.uk/iiif/manifest/f22e9dae-c070-48eb-be0b-aa6c5bc195a6.json",
-    //"query-gams": "http://gams.uni-graz.at/cocoon/mets2json?source=http%3A%2F%2Fgams.uni-graz.at%2Farchive%2Fget%2Fo%3Asrbas.1535%2FMETS_SOURCE"
+    //"query-gams": "http://gams.uni-graz.at/cocoon/mets2json?source=http%3A%2F%2Fgams.uni-graz.at%2Farchive%2Fget%2Fo%3Asrbas.1535%2FMETS_SOURCE",
+    "v3ProviderNoLogo": "http://localhost:3001/YaleCanterburyTalesV3ProviderNoLogo.json"
 };
 
 //BBoM: http://wellcomelibrary.org/iiif/b18031511/manifest

--- a/test/index.js
+++ b/test/index.js
@@ -93,3 +93,4 @@ importTest('tankeryshouse', './tests/tankeryshouse');
 importTest('translations', './tests/translations');
 importTest('witnesstopeter', './tests/witnesstopeter');
 importTest('Utils', './tests/Utils.test');
+importTest('v3ProviderNoLogo', './tests/v3ProviderNoLogo');

--- a/test/tests/v3ProviderNoLogo.js
+++ b/test/tests/v3ProviderNoLogo.js
@@ -1,0 +1,22 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../dist-commonjs/');
+var manifests = require('../fixtures/manifests');
+
+var manifest, logo;
+
+describe('#logo', function() {
+
+    it('manifest loads successfully', function (done) {
+        manifesto.loadManifest(manifests.v3ProviderNoLogo).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    it('has no logo', function () {
+        logo = manifest.getLogo();
+        expect(logo).to.equal(null);
+    });
+
+});


### PR DESCRIPTION
The last update to getLogo() caused an error when parsing v3 manifests with an agent/provider property but no logo: 'Cannot read properties of undefined (reading 'logo')'. This should fix that by checking more thoroughly for the existence of agent/provider. Test for this type of manifest also added.