### PR TITLE
fix empty required statement items in metadata component

### DIFF
--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -161,7 +161,7 @@ export class IIIFResource extends ManifestResource {
       // fall back to attribution (if it exists)
       const attribution: PropertyValue = this.getAttribution();
 
-      if (attribution) {
+      if (attribution && attribution.length) {
         requiredStatement = new LabelValuePair(this.options.locale);
         requiredStatement.value = attribution;
       }


### PR DESCRIPTION
iiif-metadata-component has a bug where an empty item is added with empty strings for label and value.
This is because the getRequiredStatement method in manifesto currently has a fallback to getAttribution if no required statement is found. getAttribution always returns something, even if no attribution is found. One option would be to remove the fallback entirely (so getRequiredStatement never has a back-up from the now deprecated Attribution property), but I suspect there might be other reasons for having getAttribution always returning something. So this adjustment checks that it contains values before creating the metadata item.