### PR TITLE
bump node version on npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - run: npm ci
       - run: npm run build
       - run: npm run test
@@ -39,7 +39,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Set tag
         id: tagName


### PR DESCRIPTION
Checks for node 20 in github actions (as described here: https://github.com/UniversalViewer/universalviewer/issues/1483) 