### PR TITLE
change refs to master branch to refs to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # manifesto
 
-[![Build Status](https://github.com/IIIF-Commons/manifesto/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/IIIF-Commons/manifesto/actions/workflows/build-test.yml)
+[![Build Status](https://github.com/IIIF-Commons/manifesto/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/IIIF-Commons/manifesto/actions/workflows/build-test.yml)
 
 IIIF Presentation API client and server utility library.
 
@@ -26,9 +26,9 @@ https://iiif-commons.github.io/manifesto/
 
 ### Publishing Package
 
-    git checkout master
+    git checkout main
     npm version patch
     git add .
     git commit -m "Release v1.2.3"
     git tag v1.2.3
-    git push origin master v1.2.3
+    git push origin main v1.2.3

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,7 +65,7 @@
 		<div class="col-8 col-content">
 			<div class="tsd-panel tsd-typography">
 				<h1 id="manifesto">manifesto</h1>
-				<p><a href="https://travis-ci.org/IIIF-Commons/manifesto"><img src="https://travis-ci.org/IIIF-Commons/manifesto.svg?branch=master" alt="Build Status"></a></p>
+				<p><a href="https://travis-ci.org/IIIF-Commons/manifesto"><img src="https://travis-ci.org/IIIF-Commons/manifesto.svg?branch=main" alt="Build Status"></a></p>
 				<p>IIIF Presentation API client and server utility library.</p>
 				<pre><code>npm <span class="hljs-keyword">install </span>manifesto.<span class="hljs-keyword">js </span>--save</code></pre><h2 id="getting-started">Getting Started</h2>
 				<h3 id="documentation">Documentation</h3>
@@ -78,9 +78,9 @@
 <span class="hljs-built_in">npm</span> build
 <span class="hljs-built_in">npm</span> test</code></pre><h3 id="publishing-package">Publishing Package</h3>
 				<ol>
-					<li>Bump the version locally using <code>npm version</code> on a branch other than <code>master</code>. Example: <code>npm version patch -m &#39;bump to v3.0.42&#39;</code></li>
-					<li>Push the bump version branch to GitHub and create a pull request to <code>master</code>.</li>
-					<li>After the pull request is merged, checkout <code>master</code> and pull the latest changes. <code>git checkout master &amp;&amp; git pull</code></li>
+					<li>Bump the version locally using <code>npm version</code> on a branch other than <code>main</code>. Example: <code>npm version patch -m &#39;bump to v3.0.42&#39;</code></li>
+					<li>Push the bump version branch to GitHub and create a pull request to <code>main</code>.</li>
+					<li>After the pull request is merged, checkout <code>main</code> and pull the latest changes. <code>git checkout main &amp;&amp; git pull</code></li>
 					<li>Run <code>npm publish</code></li>
 					<li>Push the git tags created <code>git push --tags</code></li>
 				</ol>


### PR DESCRIPTION
changes references to the old master branch to the newly renamed main branch in documentation etc.

Part of https://github.com/UniversalViewer/universalviewer/issues/1483