### PR TITLE
Check for array in viewingHint

### DIFF
--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -309,7 +309,17 @@ export class Canvas extends Resource {
   }
 
   getViewingHint(): ViewingHint | null {
-    return this.getProperty("viewingHint");
+    let viewingHint: any = this.getProperty("viewingHint");
+
+    if (Array.isArray(viewingHint)) {
+      viewingHint = viewingHint[0];
+    }
+
+    if (viewingHint) {
+      return viewingHint;
+    }
+
+    return null;
   }
 
   get imageResources() {

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -120,7 +120,17 @@ export class Collection extends IIIFResource {
   }
 
   getViewingHint(): ViewingHint | null {
-    return this.getProperty("viewingHint");
+    let viewingHint: any = this.getProperty("viewingHint");
+
+    if (Array.isArray(viewingHint)) {
+      viewingHint = viewingHint[0];
+    }
+
+    if (viewingHint) {
+      return viewingHint;
+    }
+
+    return null;
   }
 
   /**

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -314,6 +314,16 @@ export class Manifest extends IIIFResource {
   }
 
   getViewingHint(): ViewingHint | null {
-    return this.getProperty("viewingHint");
+    let viewingHint: any = this.getProperty("viewingHint");
+
+    if (Array.isArray(viewingHint)) {
+      viewingHint = viewingHint[0];
+    }
+
+    if (viewingHint) {
+      return viewingHint;
+    }
+
+    return null;
   }
 }

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -167,7 +167,17 @@ export class Range extends ManifestResource {
   }
 
   getViewingHint(): ViewingHint | null {
-    return this.getProperty("viewingHint");
+    let viewingHint: any = this.getProperty("viewingHint");
+
+    if (Array.isArray(viewingHint)) {
+      viewingHint = viewingHint[0];
+    }
+
+    if (viewingHint) {
+      return viewingHint;
+    }
+
+    return null;
   }
 
   getTree(treeRoot: TreeNode): TreeNode {

--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -287,7 +287,17 @@ export class Sequence extends ManifestResource {
   }
 
   getViewingHint(): ViewingHint | null {
-    return this.getProperty("viewingHint");
+    let viewingHint: any = this.getProperty("viewingHint");
+
+    if (Array.isArray(viewingHint)) {
+      viewingHint = viewingHint[0];
+    }
+
+    if (viewingHint) {
+      return viewingHint;
+    }
+
+    return null;
   }
 
   isCanvasIndexOutOfRange(canvasIndex: number): boolean {


### PR DESCRIPTION
This will allow the `viewingHint` in a v2 manifest have an array of values, as suggested by this issue submitted to UV: https://github.com/UniversalViewer/universalviewer/issues/627

I'm a little sceptical about this, as in practice everyone presents their viewingHint as a string, and the spec isn't very specific about giving multiple values. I've asked about it in the IIIF Slack here, so maybe some clarification will follow: https://iiif.slack.com/archives/C18FHBKAQ/p1753799191719489

One of the reasons to be sceptical is that this would allow a hypothetical manifest with conflicting viewingHints (e.g. `viewingHint: ["individuals", "paged"]`. Where should this be validated and how should it be handled? 

However, manifesto doesn't currently handle this for the v3 `behavior` property, where arrays are a must; it just returns the first one. See this comment and code in the Collection helper:





```
  /**
   * Note: this only will return the first behavior as per the manifesto convention
   * IIIF v3 supports multiple behaviors
   */
    getBehavior(): Behavior | null {
    let behavior: any = this.getProperty("behavior");

    if (Array.isArray(behavior)) {
      behavior = behavior[0];
    }

    if (behavior) {
      return behavior;
    }

    return null;
  }
```

So, I've just followed this handling for the viewingHint, which should suffice until we think more deeply about `behaviour` (and on that note, the v3 spec acknowledges more info is needed: "Further clarifications about the implications of interactions between behavior values should be expected in subsequent minor releases.")