### PR TITLE
Support for v3 annotations

### DIFF
--- a/src/AnnotationBody.ts
+++ b/src/AnnotationBody.ts
@@ -31,6 +31,14 @@ export class AnnotationBody extends ManifestResource {
     return null;
   }
 
+  getValue(): string | null {
+    return this.getProperty("value");
+  }
+
+  getLanguage(): string | null {
+    return this.getProperty("language");
+  }
+
   getWidth(): number {
     return this.getProperty("width");
   }

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -212,6 +212,22 @@ export class Canvas extends Resource {
     return content;
   }
 
+  getAnnotations(): AnnotationPage[] {
+    const annotationPages: AnnotationPage[] = [];
+    const pages = this.__jsonld.annotations;
+
+    if (!pages || !Array.isArray(pages)) {
+      return annotationPages;
+    }
+
+    for (let i = 0; i < pages.length; i++) {
+      const annotationPage = new AnnotationPage(pages[i], this.options);
+      annotationPages.push(annotationPage);
+    }
+
+    return annotationPages;
+  }
+
   getDuration(): number | null {
     return this.getProperty("duration");
   }

--- a/test/fixtures/manifests.js
+++ b/test/fixtures/manifests.js
@@ -61,7 +61,8 @@ module.exports = {
     "riksmuseumimageapiv3thumbnails": "http://localhost:3001/riksmuseum-image-api-v3-thumbnails.json",
     //"query-bodleian": "http://iiif.bodleian.ox.ac.uk/iiif/manifest/f22e9dae-c070-48eb-be0b-aa6c5bc195a6.json",
     //"query-gams": "http://gams.uni-graz.at/cocoon/mets2json?source=http%3A%2F%2Fgams.uni-graz.at%2Farchive%2Fget%2Fo%3Asrbas.1535%2FMETS_SOURCE",
-    "v3ProviderNoLogo": "http://localhost:3001/YaleCanterburyTalesV3ProviderNoLogo.json"
+    "v3ProviderNoLogo": "http://localhost:3001/YaleCanterburyTalesV3ProviderNoLogo.json",
+    "pres3AnnotationsEmbedded": "http://localhost:3001/pres3-annotations-embedded.json"
 };
 
 //BBoM: http://wellcomelibrary.org/iiif/b18031511/manifest

--- a/test/fixtures/pres3-annotations-embedded.json
+++ b/test/fixtures/pres3-annotations-embedded.json
@@ -1,0 +1,66 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Picture of Göttingen taken during the 2019 IIIF Conference"
+    ]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1",
+      "type": "Canvas",
+      "height": 3024,
+      "width": 4032,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1/annopage-1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1/annopage-1/anno-1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3024,
+                "width": 4032,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+                    "profile": "level1",
+                    "type": "ImageService3"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1/annopage-2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1/annopage-2/anno-1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "language": "de",
+                "format": "text/plain",
+                "value": "Göttinger Marktplatz mit Gänseliesel Brunnen"
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -94,3 +94,4 @@ importTest('translations', './tests/translations');
 importTest('witnesstopeter', './tests/witnesstopeter');
 importTest('Utils', './tests/Utils.test');
 importTest('v3ProviderNoLogo', './tests/v3ProviderNoLogo');
+importTest('pres3AnnotationsEmbedded', './tests/pres3-annotations-embedded');

--- a/test/tests/pres3-annotations-embedded.js
+++ b/test/tests/pres3-annotations-embedded.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var manifest, canvas, annotationPages;
+var manifest, canvas, annotationPages, annotations, annotation, body
 
 describe('#getAnnotations', function() {
   it('manifest loads successfully', function (done) {
@@ -19,7 +19,6 @@ it('has a sequence', function() {
 
 it('has a canvas', function() {
     canvas = sequence.getCanvases()[0];
-    console.log(canvas)
     expect(canvas).to.exist;
 });
 
@@ -34,19 +33,19 @@ it('has a canvas', function() {
   });
 
   it('annotation page contains annotations', function () {
-    var annotations = annotationPages[0].getItems();
+    annotations = annotationPages[0].getItems();
     expect(annotations).to.be.an('array');
     expect(annotations).to.have.lengthOf(1);
   });
 
   it('annotation has commenting motivation', function () {
-    var annotations = annotationPages[0].getItems();
-    var annotation = new manifesto.Annotation(annotations[0]);
+    annotations = annotationPages[0].getItems();
+    annotation = new manifesto.Annotation(annotations[0]);
     expect(annotation.getMotivation()).to.equal('commenting');
   });
 
   it('annotation body has value', function () {
-    var body = annotation.getBody()[0];
+    body = annotation.getBody()[0];
     expect(body.getValue()).to.equal('Göttinger Marktplatz mit Gänseliesel Brunnen');
   });
 

--- a/test/tests/pres3-annotations-embedded.js
+++ b/test/tests/pres3-annotations-embedded.js
@@ -1,0 +1,47 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../dist-commonjs/');
+var manifests = require('../fixtures/manifests');
+var manifest, canvas, annotationPages;
+
+describe('#getAnnotations', function() {
+  it('manifest loads successfully', function (done) {
+    manifesto.loadManifest(manifests.pres3AnnotationsEmbedded).then(function(data) {
+      manifest = manifesto.parseManifest(data);
+      done();
+    });
+  });
+
+it('has a sequence', function() {
+    sequence = manifest.getSequenceByIndex(0);
+    expect(sequence).to.exist;
+});
+
+it('has a canvas', function() {
+    canvas = sequence.getCanvases()[0];
+    console.log(canvas)
+    expect(canvas).to.exist;
+});
+
+  it('has annotation pages', function () {
+    annotationPages = canvas.getAnnotations();
+    expect(annotationPages).to.be.an('array');
+    expect(annotationPages).to.have.lengthOf(1);
+  });
+
+  it('annotation page has correct id', function () {
+    expect(annotationPages[0].id).to.equal('https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1/annopage-2');
+  });
+
+  it('annotation page contains annotations', function () {
+    var annotations = annotationPages[0].getItems();
+    expect(annotations).to.be.an('array');
+    expect(annotations).to.have.lengthOf(1);
+  });
+
+  it('annotation has commenting motivation', function () {
+    var annotations = annotationPages[0].getItems();
+    var annotation = new manifesto.Annotation(annotations[0]);
+    expect(annotation.getMotivation()).to.equal('commenting');
+  });
+});

--- a/test/tests/pres3-annotations-embedded.js
+++ b/test/tests/pres3-annotations-embedded.js
@@ -44,4 +44,13 @@ it('has a canvas', function() {
     var annotation = new manifesto.Annotation(annotations[0]);
     expect(annotation.getMotivation()).to.equal('commenting');
   });
+
+  it('annotation body has value', function () {
+    var body = annotation.getBody()[0];
+    expect(body.getValue()).to.equal('Göttinger Marktplatz mit Gänseliesel Brunnen');
+  });
+
+  it('annotation body has language', function () {
+    expect(body.getLanguage()).to.equal('de');
+  });
 });


### PR DESCRIPTION
This adds support for Presentation 3 annotations on the canvas, adding

- getAnnotations to canvas
- getValue to annotationBody
- getLanguage to annotationBody

This addresses https://github.com/IIIF-Commons/manifesto/issues/125 and supports ongoing work on annotation display in UV