### PR TITLE
Fix annotationPage getItems to return Annotations[]

### DIFF
--- a/src/AnnotationPage.ts
+++ b/src/AnnotationPage.ts
@@ -6,6 +6,18 @@ export class AnnotationPage extends ManifestResource {
   }
 
   getItems(): Annotation[] {
-    return this.getProperty("items");
+    const items: Annotation[] = []
+    const rawItems = this.getProperty("items");
+
+    if (!rawItems || !Array.isArray(rawItems)) {
+      return items;
+    }
+    
+    for (let i = 0; i < rawItems.length; i++) {
+      const annotation = new Annotation(i, this.options);
+      items.push(annotation);
+    }
+
+    return items
   }
 }

--- a/src/AnnotationPage.ts
+++ b/src/AnnotationPage.ts
@@ -6,18 +6,18 @@ export class AnnotationPage extends ManifestResource {
   }
 
   getItems(): Annotation[] {
-    const items: Annotation[] = []
+    const items: Annotation[] = [];
     const rawItems = this.getProperty("items");
 
     if (!rawItems || !Array.isArray(rawItems)) {
       return items;
     }
-    
+
     for (let i = 0; i < rawItems.length; i++) {
-      const annotation = new Annotation(i, this.options);
+      const annotation = new Annotation(rawItems[i], this.options);
       items.push(annotation);
     }
 
-    return items
+    return items;
   }
 }

--- a/src/AnnotationPage.ts
+++ b/src/AnnotationPage.ts
@@ -5,7 +5,14 @@ export class AnnotationPage extends ManifestResource {
     super(jsonld, options);
   }
 
-  getItems(): Annotation[] {
+  /**
+   * @deprecated Use getAnnotations() instead
+   */
+  getItems(): any[] {
+    return this.getProperty("items");
+  }
+
+  getAnnotations(): Annotation[] {
     const items: Annotation[] = [];
     const rawItems = this.getProperty("items");
 

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -205,8 +205,7 @@ export class Canvas extends Resource {
 
     for (let i = 0; i < annotations.length; i++) {
       const a = annotations[i];
-      const annotation = new Annotation(a, this.options);
-      content.push(annotation);
+      content.push(a);
     }
 
     return content;

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -201,7 +201,7 @@ export class Canvas extends Resource {
       return content;
     }
 
-    const annotations: Annotation[] = annotationPage.getItems();
+    const annotations: Annotation[] = annotationPage.getAnnotations();
 
     for (let i = 0; i < annotations.length; i++) {
       const a = annotations[i];

--- a/test/tests/pres3-annotations-embedded.js
+++ b/test/tests/pres3-annotations-embedded.js
@@ -33,13 +33,13 @@ it('has a canvas', function() {
   });
 
   it('annotation page contains annotations', function () {
-    annotations = annotationPages[0].getItems();
+    annotations = annotationPages[0].getAnnotations();
     expect(annotations).to.be.an('array');
     expect(annotations).to.have.lengthOf(1);
   });
 
   it('annotation has commenting motivation', function () {
-    annotations = annotationPages[0].getItems();
+    annotations = annotationPages[0].getAnnotations();
     annotation = annotations[0];
     expect(annotation.getMotivation()).to.equal('commenting');
   });

--- a/test/tests/pres3-annotations-embedded.js
+++ b/test/tests/pres3-annotations-embedded.js
@@ -40,7 +40,7 @@ it('has a canvas', function() {
 
   it('annotation has commenting motivation', function () {
     annotations = annotationPages[0].getItems();
-    annotation = new manifesto.Annotation(annotations[0]);
+    annotation = annotations[0];
     expect(annotation.getMotivation()).to.equal('commenting');
   });
 


### PR DESCRIPTION
Potentially a breaking change.

`annotationPage` has a method, `getItems`, to return an array of annotations. The type for the return is set as `Annotation[]`, but in fact it's returning raw JSON because it's just wrapping the `getProperty` method. This means that anything using `getItems` has to use a workaround, creating `Annotation` instances from the return of `getItems` (e.g. in the Canvas method `getContent`; work on UV with annotations would have to create annotation instances too).

This seems inconsistent with other getter methods in Manifesto, which handle the instantiation. This PR makes sure `getItems` returns an array of `Annotation`s, not just JSON. It also updates `getContent` to reflect the change, and adjusts one of the tests accordingly.

UV doesn't currently call `getItems` anywhere, but anything else depending on Manifesto might! This would break it, so I'm not sure the best way of proceeding with this. For now, in UV, I can just use the workaround. 
