### PR TITLE
Add getChoices to canvas

### DIFF
--- a/src/Annotation.ts
+++ b/src/Annotation.ts
@@ -23,6 +23,7 @@ export class Annotation extends ManifestResource {
           if (b.items) {
             for (let i = 0; i < b.items.length; i++) {
               // todo: don't ignore that it's a choice. maybe add isChoice() to IAnnotationBody?
+              // When done, can use getBody in getChoices method on Canvas instead of current workaround.
               const c: any = b.items[i];
               bodies.push(new AnnotationBody(c, this.options));
             }

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -432,16 +432,18 @@ export class Canvas extends Resource {
 
   getChoices(): AnnotationBody[] {
     const content = this.getContent();
-    
+
     for (const annotation of content) {
-      const body = annotation.getBody();
-      if (body.length && body[0].getProperty("type")?.toLowerCase() === ExternalResourceType.CHOICE) {
-        const items = body[0].getProperty("items");
-        if (items && items.length) {
-          return items.map((item: any) => new AnnotationBody(item, this.options));
+      const body = annotation.getProperty("body");
+      if (body && body.type?.toLowerCase() === ExternalResourceType.CHOICE) {
+        if (body.items && body.items.length) {
+          return body.items.map(
+            (item: any) => new AnnotationBody(item, this.options)
+          );
         }
       }
     }
+
     return [];
   }
 }

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -429,4 +429,19 @@ export class Canvas extends Resource {
   get aspectRatio() {
     return this.getWidth() / this.getHeight();
   }
+
+  getChoices(): AnnotationBody[] {
+    const content = this.getContent();
+    
+    for (const annotation of content) {
+      const body = annotation.getBody();
+      if (body.length && body[0].getProperty("type")?.toLowerCase() === ExternalResourceType.CHOICE) {
+        const items = body[0].getProperty("items");
+        if (items && items.length) {
+          return items.map((item: any) => new AnnotationBody(item, this.options));
+        }
+      }
+    }
+    return [];
+  }
 }

--- a/test/fixtures/choice.json
+++ b/test/fixtures/choice.json
@@ -1,0 +1,75 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0033-choice/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "John Dee performing an experiment before Queen Elizabeth I."
+    ]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0033-choice/canvas/p1",
+      "type": "Canvas",
+      "height": 1271,
+      "width": 2000,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0033-choice/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0033-choice/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural/full/max/0/default.jpg",
+                    "type": "Image",
+                    "format": "image/jpeg",
+                    "width": 2000,
+                    "height": 1271,
+                    "label": {
+                      "en": [
+                        "Natural Light"
+                      ]
+                    },
+                    "service": [
+                      {
+                        "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural",
+                        "type": "ImageService3",
+                        "profile": "level1"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray/full/max/0/default.jpg",
+                    "type": "Image",
+                    "format": "image/jpeg",
+                    "width": 2000,
+                    "height": 1271,
+                    "label": {
+                      "en": [
+                        "X-Ray"
+                      ]
+                    },
+                    "service": [
+                      {
+                        "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray",
+                        "type": "ImageService3",
+                        "profile": "level1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0033-choice/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/manifests.js
+++ b/test/fixtures/manifests.js
@@ -64,6 +64,7 @@ module.exports = {
     "v3ProviderNoLogo": "http://localhost:3001/YaleCanterburyTalesV3ProviderNoLogo.json",
     "pres3AnnotationsEmbedded": "http://localhost:3001/pres3-annotations-embedded.json",
     "maxWidthImageApi3": "http://localhost:3001/max-width-image-api-3.json",
+    "choice": "http://localhost:3001/choice.json",
 };
 
 //BBoM: http://wellcomelibrary.org/iiif/b18031511/manifest

--- a/test/index.js
+++ b/test/index.js
@@ -97,3 +97,4 @@ importTest('Utils', './tests/Utils.test');
 importTest('v3ProviderNoLogo', './tests/v3ProviderNoLogo');
 importTest('pres3AnnotationsEmbedded', './tests/pres3-annotations-embedded');
 importTest('maxWidthImageApi3', './tests/max-width-image-api-3');
+importTest('choice', './tests/choice');

--- a/test/tests/choice.js
+++ b/test/tests/choice.js
@@ -1,0 +1,55 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../dist-commonjs/');
+var manifests = require('../fixtures/manifests');
+var manifest, sequence, canvas, choices;
+
+describe('choice', function() {
+    it('loads successfully', function(done) {
+        manifesto.loadManifest(manifests.choice).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    it('has a sequence', function() {
+        sequence = manifest.getSequenceByIndex(0);
+        expect(sequence).to.exist;
+    });
+
+    it('has a canvas', function() {
+        canvas = sequence.getCanvases()[0];
+        expect(canvas).to.exist;
+    });
+
+    it('has choices', function() {
+        choices = canvas.getChoices();
+        expect(choices).to.exist;
+        expect(choices.length).to.equal(2);
+    });
+
+    it('choice items have labels', function() {
+        expect(choices[0].getLabel().getValue()).to.equal('Natural Light');
+        expect(choices[1].getLabel().getValue()).to.equal('X-Ray');
+    });
+
+    it('choice items have services', function() {
+        var services = choices[0].getServices();
+        expect(services).to.exist;
+        expect(services.length).to.be.greaterThan(0);
+    });
+
+    it('choice items have dimensions', function() {
+        expect(choices[0].getWidth()).to.equal(2000);
+        expect(choices[0].getHeight()).to.equal(1271);
+    });
+
+    // it('returns empty array for canvas without choices', function() {
+    //     var nonChoiceCanvas = sequence.getCanvases()[0];
+    //     // use a fixture canvas known to have no choices
+    //     var emptyChoices = nonChoiceCanvas.getChoices();
+    //     // this test would use a different fixture — just illustrating the pattern
+    //     expect(emptyChoices).to.be.an('array');
+    //     expect(emptyChoices.length).to.equal(0);
+    // });
+});

--- a/test/tests/choice.js
+++ b/test/tests/choice.js
@@ -43,13 +43,4 @@ describe('choice', function() {
         expect(choices[0].getWidth()).to.equal(2000);
         expect(choices[0].getHeight()).to.equal(1271);
     });
-
-    // it('returns empty array for canvas without choices', function() {
-    //     var nonChoiceCanvas = sequence.getCanvases()[0];
-    //     // use a fixture canvas known to have no choices
-    //     var emptyChoices = nonChoiceCanvas.getChoices();
-    //     // this test would use a different fixture — just illustrating the pattern
-    //     expect(emptyChoices).to.be.an('array');
-    //     expect(emptyChoices.length).to.equal(0);
-    // });
 });

--- a/test/tests/pres3.js
+++ b/test/tests/pres3.js
@@ -56,4 +56,11 @@ describe('presentation 3', function() {
         var rights = manifest.getRights();
         expect(rights).to.equal('http://example.org/license.html');
     });
+
+    it('returns empty array for canvas without choices', function() {
+        var nonChoiceCanvas = sequence.getCanvases()[0];
+        var emptyChoices = nonChoiceCanvas.getChoices();
+        expect(emptyChoices).to.be.an('array');
+        expect(emptyChoices.length).to.equal(0);
+    });
 });


### PR DESCRIPTION
This adds a method to the canvas to get choices, if they exist, as `AnnotationBody[]`.

I'm currently using

`const body = annotation.getProperty("body");`

rather than the native

`const body = annotation.getBody();`

because `getBody` currently flattens choices out. There is an old comment in Annotation.ts:

`// todo: don't ignore that it's a choice. maybe add isChoice() to IAnnotationBody?`

Addressing this will take a bit more time and thought so I'll come back to it. 

