### PR TITLE
Replace lodash with javascript builtins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@edsilv/http-status-codes": "^1.0.3",
         "@iiif/vocabulary": "^1.0.28",
-        "isomorphic-unfetch": "^3.0.0",
-        "lodash": "^4.17.21"
+        "isomorphic-unfetch": "^3.0.0"
       },
       "devDependencies": {
         "@types/node": "24.0.10",
@@ -2829,12 +2828,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
   "dependencies": {
     "@edsilv/http-status-codes": "^1.0.3",
     "@iiif/vocabulary": "^1.0.28",
-    "isomorphic-unfetch": "^3.0.0",
-    "lodash": "^4.17.21"
+    "isomorphic-unfetch": "^3.0.0"
   },
   "directories": {
     "test": "test"

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -15,10 +15,6 @@ import {
   Size,
   Utils,
 } from "./internal";
-// @ts-ignore
-import flatten from "lodash/flatten";
-// @ts-ignore
-import flattenDeep from "lodash/flattenDeep";
 
 export class Canvas extends Resource {
   public ranges: Range[];
@@ -353,22 +349,26 @@ export class Canvas extends Resource {
   }
 
   get imageResources() {
-    const resources = flattenDeep([
-      this.getImages().map((i) => i.getResource()),
-      this.getContent().map((i) => i.getBody()),
-    ]);
+    const resources = (
+      [
+        this.getImages().map((i) => i.getResource()),
+        this.getContent().map((i) => i.getBody()),
+      ] as any[]
+    ).flat(Infinity);
 
-    return flatten(
-      resources.map((resource) => {
+    return resources
+      .map((resource) => {
         switch (resource.getProperty("type").toLowerCase()) {
           case ExternalResourceType.CHOICE:
           case ExternalResourceType.OA_CHOICE:
             return new Canvas(
               {
-                images: flatten([
+                images: [
                   resource.getProperty("default"),
                   resource.getProperty("item"),
-                ]).map((r) => ({ resource: r })),
+                ]
+                  .flat()
+                  .map((r) => ({ resource: r })),
               },
               this.options
             )
@@ -378,11 +378,13 @@ export class Canvas extends Resource {
             return resource;
         }
       })
-    );
+      .flat();
   }
 
   get resourceAnnotations() {
-    return flattenDeep([this.getImages(), this.getContent()]);
+    return (
+      [this.getImages(), this.getContent()] as any[]
+    ).flat(Infinity);
   }
 
   /**
@@ -393,7 +395,7 @@ export class Canvas extends Resource {
     return this.resourceAnnotations.find(
       (anno) =>
         anno.getResource().id === id ||
-        flatten(new Array(anno.getBody())).some((body) => body.id === id)
+        [anno.getBody()].flat().some((body) => body.id === id)
     );
   }
 


### PR DESCRIPTION
We don't need the lodash dependency, because Array.prototype.flat() does what we need


See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat